### PR TITLE
Debug extensions as submodules error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,10 +102,10 @@ services:
       # mount LocalSettings.d and extensions explicitly, as long as these are mounted from the host
       # (otherwise restore throws error)
       - ./mediawiki/LocalSettings.d:/var/www/html/LocalSettings.d
-      - ./mediawiki/extensions/TemplateStyles:/var/www/html/extensions/TemplateStyles
-      - ./mediawiki/extensions/JsonConfig:/var/www/html/extensions/JsonConfig
-      - ./mediawiki/extensions/Math:/var/www/html/extensions/Math
-      - ./mediawiki/extensions/MathSearch:/var/www/html/extensions/MathSearch
+      #- ./mediawiki/extensions/TemplateStyles:/var/www/html/extensions/TemplateStyles
+      #- ./mediawiki/extensions/JsonConfig:/var/www/html/extensions/JsonConfig
+      #- ./mediawiki/extensions/Math:/var/www/html/extensions/Math
+      #- ./mediawiki/extensions/MathSearch:/var/www/html/extensions/MathSearch
       # dir on host where to store the backups
       - ${BACKUP_DIR:-./backup}:/data
       # only for running tests


### PR DESCRIPTION
# MaRDI Pull Request
CI gives an error when sharing a volume that includes mounted submodules

**Goal**: 
Make build pass

**Changes**:
Extensions in submodules rea now not mounted explicitly anymore.
