### PR TITLE
Prom2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,9 @@ WIKIBASE_PORT=8080
 WDQS_FRONTEND_PORT=8834
 QUICKSTATEMENTS_HOST=localhost
 QUICKSTATEMENTS_PORT=8840
+GRAFANA_PORT=3000
 RESTART='no'
 ```
-
-The local install has 2 additional containers:
-* Selenium for running tests
-* Openrefine for data manipulation
-
-The local install also has open ports, so that the services can be accessed without using the reverse proxy
-* Wikibase, http://localhost:8080
-* WDQS Frontend, http://localhost:8834
-* Quickstatements, http://localhost:8840
-* OpenRefine, http://localhost:3333
-
-Note that the containers for local development are set to not restart, 
-so that they do not start automatically when you start your computer.
 
 ## Start up the containers
 Start-up the containers from the docker-compose file for development:
@@ -51,7 +39,21 @@ docker-compose -f docker-compose.yml -f docker-compose-dev.yml down
 
 (Tipp: add these two commands to your `~/.bash_aliases`)
 
-## Test locally
+The local install has 2 additional containers:
+* Selenium for running tests
+* Openrefine for data manipulation
+
+The local install also has open ports, so that the services can be accessed without using the reverse proxy
+* Wikibase, http://localhost:8080
+* WDQS Frontend, http://localhost:8834
+* Quickstatements, http://localhost:8840
+* WB query service frontend, http://localhost:8834
+* OpenRefine, http://localhost:3333
+
+Note that the containers for local development are set to not restart, 
+so that they do not start automatically when you start your computer.
+
+### Test locally
 Run the tests: `bash ./run_tests.sh`
 
 ## Build on CI 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The local install also has open ports, so that the services can be accessed with
 * Quickstatements, http://localhost:8840
 * WB query service frontend, http://localhost:8834
 * OpenRefine, http://localhost:3333
+* Grafana, http://localhost:3000
 
 Note that the containers for local development are set to not restart, 
 so that they do not start automatically when you start your computer.

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -43,4 +43,4 @@ services:
 
   grafana:
     ports:
-      - "${GRAFANA_PORT}:3000"
+      - "3000:3000"

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -7,6 +7,7 @@ x-common-variables: &wikibase_variables
     WDQS_FRONTEND_PORT: 8834
     QUICKSTATEMENTS_HOST: localhost
     QUICKSTATEMENTS_PORT: 8840
+    GRAFANA_PORT: 3000
     # required by quickstatements for creating OAuth consumers,
     # and by wikibase for redirecting back to quickstatements
     QS_PUBLIC_SCHEME_HOST_AND_PORT: 'http://${QUICKSTATEMENTS_HOST}:${QUICKSTATEMENTS_PORT}'
@@ -39,3 +40,7 @@ services:
     volumes:
       # only for running tests
       - ./test:/test
+
+  grafana:
+    ports:
+      - "${GRAFANA_PORT}:3000"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -25,8 +25,6 @@ services:
     ports:
      - "${WDQS_FRONTEND_PORT}:80"
     restart: ${RESTART}
-    environment:
-      - WIKIBASE_HOST=wikibase.svc # ? see https://github.com/MaRDI4NFDI/portal-compose/issues/35
 
   quickstatements:
     ports:
@@ -84,3 +82,11 @@ services:
       - REFINE_PORT=3333
       - REFINE_MEMORY=1024M
       - REFINE_DATA_DIR=/data
+
+  prometheus:
+    restart: ${RESTART}
+
+  grafana:
+    restart: ${RESTART}
+    ports:
+      - "${GRAFANA_PORT}:3000"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -84,6 +84,8 @@ services:
       - REFINE_DATA_DIR=/data
 
   prometheus:
+    ports:
+      - "9090:9090"
     restart: ${RESTART}
 
   grafana:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -247,10 +247,29 @@ services:
     labels:
       - com.centurylinklabs.watchtower.enable=true
       - traefik.http.services.portainer-docker.loadbalancer.server.port=9000
+      
   latexml:
     container_name: latexml
     image: physikerwelt/latexml
     restart: always
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus/:/etc/prometheus/
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+
+  grafana:
+    image: grafana/grafana
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana_data:/var/lib/grafana
 
 volumes:
   shared:
@@ -262,3 +281,5 @@ volumes:
   elasticsearch-data:
   quickstatements-data:
   portainer-data: # volume to save settings of portainer
+  prometheus_data:
+  grafana_data:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,21 @@
+global:
+  scrape_interval:     5s
+  evaluation_interval: 5s
+
+  external_labels:
+    monitor: 'mardi-monitor'
+
+rule_files:
+  # - "first.rules"
+  # - "second.rules"
+
+scrape_configs:
+  - job_name: prometheus
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'traefik'
+    scheme: http
+    static_configs:
+      - targets: ['reverse-proxy:8082']
+

--- a/test/MonitoringTest.py
+++ b/test/MonitoringTest.py
@@ -1,0 +1,10 @@
+"""Tets that monitoring tools are working"""
+from MediawikiTest import MediawikiBase
+
+class GrafanaTest(MediawikiBase):
+    def test1(self):
+        """Test that Grafana is running."""
+        status = self.getUrlStatusCode("http://portal-compose_grafana_1:3000")
+        self.assertEquals(200, status, "Problem loading home page.")
+
+

--- a/test/MonitoringTest.py
+++ b/test/MonitoringTest.py
@@ -1,4 +1,4 @@
-"""Tets that monitoring tools are working"""
+"""Test that monitoring tools are working"""
 from MediawikiTest import MediawikiBase
 
 class GrafanaTest(MediawikiBase):

--- a/test/MonitoringTest.py
+++ b/test/MonitoringTest.py
@@ -5,6 +5,10 @@ class GrafanaTest(MediawikiBase):
     def test1(self):
         """Test that Grafana is running."""
         status = self.getUrlStatusCode("http://portal-compose_grafana_1:3000")
-        self.assertEquals(200, status, "Problem loading home page.")
+        self.assertEquals(200, status, "Problem loading Grafana start page.")
 
+    def test2(self):
+        """Test that Prometheus is running."""
+        status = self.getUrlStatusCode("http://portal-compose_prometheus_1:9090")
+        self.assertEquals(200, status, "Problem loading Prometheus start page.")
 


### PR DESCRIPTION
# MaRDI Pull Request

**Goal**: 
I wanted to [merge the prom branch](https://github.com/MaRDI4NFDI/portal-compose/pull/16) but that caused a mega conflict, as the extensions are still copied into the source tree instead of linked as submodules. Since the conflict is unrelated to the actual issue, I thought it would be easier to re-create the pull request.
* If you agree with the PR, then I would delete the old push request.
* The Grafana dashboard is not connected to any data source, I would add an extra issue for that

**Changes**:
- Updated README, note that you will have to add stuff to .env to run locally
- Added Grafana and Prometheus to docker-compose.yml
- Added prometheus/prometheus.yml configuration file, edited it so that the Prometheus service starts
- Opened a port to Grafana in docker-compose-ci.yml, to run tests
- Added a test that checks if the Grafana service starts up

**Instructions for PR review**:
If you build this locally, Grafana will be accessible at http://localhost:3000 (see README)
* Login with admin/admin
* You should see an unconfigured Grafana dashboard, as no data sources have been added yet.


