### PR TITLE
Enable watchtower for reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
      - default
     labels:
       - traefik.enable=false
+      - com.centurylinklabs.watchtower.enable=true
 
   whoami:
     image: containous/whoami # A container that exposes an API to show its IP address


### PR DESCRIPTION
This will ensure the latest webproxy related fixes are applied
#73

