### PR TITLE
Control restart of watchtower in local dev environment

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -84,3 +84,6 @@ services:
       - REFINE_PORT=3333
       - REFINE_MEMORY=1024M
       - REFINE_DATA_DIR=/data
+
+  watchtower:
+    restart: ${RESTART}


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:

Changed docker-compose-dev so that restart of watchtower can be controlled while developing. Otherwise it always restarts, which is fine for the production environment, but not always what you would need for development.

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
