### PR TITLE
Remove backups earlier to save space

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
       BACKUP_SCHEDULE: 15 5 * * *
-      KEEP_DAYS: ${KEEP_DAYS:-100}
+      KEEP_DAYS: ${KEEP_DAYS:-30}
 
   reverse-proxy:
     restart: always


### PR DESCRIPTION
# MaRDI Pull Request
Backups are currently kept for 100 days. This uses +- 3 GB (will of course increase as the wiki has more data). Since we had problems with disk space, I set the default number of days to keep backups to 30. It is still possible to override this by setting the KEEP_DAYS parameter in the .env file.

**Changes**:
- KEEP_DAYS in docker-compose.yml 

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
