### PR TITLE
assign container_name mardi-backup to backup container (fixes #117)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,4 +52,4 @@ jobs:
         run: docker exec mardi-selenium bash ./start_test_runner.sh test
       -
         name: Test backups
-        run: docker exec portal-compose_backup_1 bash /test/test_backup.sh
+        run: docker exec mardi-backup bash /test/test_backup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
 
   backup:
     image: ghcr.io/mardi4nfdi/docker-backup:main
+    container_name: mardi-backup
     links:
       - mysql
     depends_on:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,6 +6,6 @@ docker exec mardi-selenium bash ./start_test_runner.sh test/
 
 printf "\nTest the backup functions"
 printf "\n----------------------------------------\n"
-docker exec portal-compose_backup_1 bash /test/test_backup.sh
+docker exec mardi-backup bash /test/test_backup.sh
 
 printf "\n"


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- backup gets `container_name: mardi-backup`
- container name is modified accordingly in `run_tests.sh`


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
