### PR TITLE
New volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
     volumes:
       ## This shares the configuration with jobrunner
-      - shared_mardi_wikibase:/var/www/html/:rw
+      - shared_mardi_wikibase_02:/var/www/html/:rw
       - ./mediawiki/LocalSettings.d:/var/www/html/LocalSettings.d
       - ./mediawiki/images/:/var/www/html/images/
       - quickstatements-data:/quickstatements/data
@@ -55,7 +55,7 @@ services:
       - mysql
     restart: always
     volumes:
-      - shared_mardi_wikibase:/shared/:ro
+      - shared_mardi_wikibase_02:/shared/:ro
       - ./mediawiki/jobrunner-entrypoint.sh:/jobrunner-entrypoint.sh
     networks:
       default:
@@ -93,7 +93,7 @@ services:
     restart: always
     volumes:
       # shared from wikibase, to run dumpBackup.php and importBackup.php
-      - shared_mardi_wikibase:/var/www/html/:ro
+      - shared_mardi_wikibase_02:/var/www/html/:ro
       - ./mediawiki/LocalSettings.d:/var/www/html/LocalSettings.d
       # dir on host where to store the backups
       - ${BACKUP_DIR:-./backup}:/data
@@ -257,7 +257,7 @@ services:
     restart: always
     
 volumes:
-  shared_mardi_wikibase:
+  shared_mardi_wikibase_02:
   mediawiki-mysql-data:
   traefik-log:
   traefik-letsencrypt:


### PR DESCRIPTION
# MaRDI Pull Request
We have a shared volume: /var/www/html from mardi-wikibase is shared with wikibase_jobrunner and backup services. As the volume is mounted on mardi-wikibase, it masks any changes to the /var/www/html folder. So every time something new is added in this folder, we have to create a new volume. This problem affects the new Layout, as the /var/www/html /skins folder is in the image, however it does not show up.

We don't want to erase the old volume just in case. Renaming volumes (e.g. shared_mardi_wikibase_OLD) is apparently not possible in Docker.

Anybody got a better idea?

**Changes**:
- portal-compose shared volume is now named "shared_mardi_wikibase_02"

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
