### PR TITLE
Moved entrypoint of backup to portal-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,9 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
-      BACKUP_SCHEDULE: 15 5 * * *
+      BACKUP_SCHEDULE: '15 4 * * *'
       KEEP_DAYS: ${KEEP_DAYS:-100}
+    entrypoint: "/app/start.sh"
 
   reverse-proxy:
     restart: always


### PR DESCRIPTION
# MaRDI Pull Request
There was a recurring problem that environment variables where not passed to the backup container. This was caused by my misconception that cronjobs are bash scripts. Since they are not, they will not read the environment variables at execution time. Several solutions are discussed here: https://www.baeldung.com/linux/load-env-variables-in-cron-job

**Changes**:
- The docker-backup image is updated so that [the start script passes the environment variables to the cronjob](https://github.com/MaRDI4NFDI/docker-backup/commit/81303a2c44546c8f5fdfbe6b1f9bed1f4fa8c36a)
- The entrypoint is set in portal-compose, so that it is called after the environment variables are defined.

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
