### PR TITLE
Traefik readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Some containers are pulled from special MaRDI images:
 * backup is pulled from https://github.com/MaRDI4NFDI/docker-backup
 * quickstatements is pulled from https://github.com/MaRDI4NFDI/docker-quickstatements
 
+### Notes on the traefik reverse proxy
+[traefik](https://doc.traefik.io/traefik/) is an edge router (or reverse
+proxies), the purpose of which is to route incoming requests to the
+corresponding services. E.g., requests to https://portal.mardi4nfdi.de are
+forwarded to the wikibase service. Services are detected and monitored automatically.
+
+To test traefik locally and access  ... continue HERE!
+
 ## Start up the containers
 Start-up the containers from the docker-compose file for development:
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ services:
 3. The traefik dashboard is protected by a password. To disable basic auth,
    comment the label defining the authentication middleware, `-
    traefik.http.routers.dashboard.middlewares=auth`. Alternatively, to test the
-   authentication, a local password hash can be generated with  `htpasswd USER
+   authentication, a local password hash can be generated with  `htpasswd -nb USER
    PASSWORD`. Write the hash in the label `-
    traefik.http.middlewares.auth.basicauth.users=USER:PASSWORD_HASH`, replacing
    all `$` by `$$`. 


### PR DESCRIPTION
# MaRDI Pull Request

issue #148 

**Changes**:
- add info about traefik to README
- add instructions for local use of traefik to README

note: it would be nice to make the proposed changes in docker-compose-dev.yml instead of docker-compose.yml, but the docker-compose overrides are lacking... it's not possible to replace the labels (or: environments, volumes, etc) defined in one file by the labels defined in the override file (or our dev). cf. https://github.com/docker/compose/issues/3729

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [x] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
