### PR TITLE
added node_exporter and utilities to monitor system metrics #150

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,7 +272,10 @@ services:
     image: alpine:latest
     volumes:
       - ./prometheus/:/etc/prometheus/:rw
-    command: sh -c "echo $TRAEFIK_PW > /etc/prometheus/traefik-pass"
+    # command: sh /etc/prometheus/setup_prometheus.sh $TRAEFIK_PW $HOST_NETWORK_IP
+    command: >
+      sh -c "echo $TRAEFIK_PW > /etc/prometheus/traefik-pass
+      && sed -i \"s/HOST_NETWORK_IP/$HOST_NETWORK_IP/\" /etc/prometheus/prometheus.yml"
 
   prometheus:
     image: prom/prometheus
@@ -305,6 +308,19 @@ services:
       - traefik.http.routers.grafana.entrypoints=websecure
       - traefik.http.routers.grafana.tls.certResolver=le
 
+  # recommended setup from
+  # https://github.com/prometheus/node_exporter/issues/671
+  # shared processes and network with host
+  node_exporter:
+    image: prom/node-exporter:latest
+    container_name: node_exporter
+    command:
+      - '--path.rootfs=/host'
+    network_mode: host
+    pid: host
+    restart: unless-stopped
+    volumes:
+      - '/:/host:ro,rslave'
     
   # Watchtower provides automatic updates for all containers
   # see https://containrrr.github.io/watchtower/arguments/

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -30,7 +30,7 @@ DB_NAME=my_wiki
 DB_USER=sqluser
 DB_PASS=change-this-sqlpassword
 
-# Traefik password for user mardi
+## Traefik password for user mardi
 TRAEFIK_PW=change-this-password
 
 ## Wikibase Configuration
@@ -54,11 +54,13 @@ QS_PUBLIC_HOST_AND_PORT=quickstatements.portal.mardi4nfdi.de
 MW_ELASTIC_HOST=elasticsearch.svc
 MW_ELASTIC_PORT=9200
 
-# Grafana
+## Grafana
 GRAFANA_PORT=3000
 
-# Prometheus
+## Prometheus
 PROMETHEUS_PORT=9090
+# Host network IP for system metrics exporter 'node_exporter'
+HOST_NETWORK_IP=set-host-network-ip
 
 ## MySQL Backup
 BACKUP_SCHEDULE='15 5 * * *' # every day at 05:15


### PR DESCRIPTION
# MaRDI Pull Request

issue #150 

**Changes**:
- setup node_exporter docker container
- setup prometheus to scrape node_exporter metrics
- introduce new environment variable $HOST_NETWORK_IP to be set in .env

**TODO**:
- [ ] write tests for metrics
- [ ] check how for instance backup can be monitored + more utilities

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
