### PR TITLE
use port 9101 instead of 9100 for node_exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -320,6 +320,7 @@ services:
     command:
       - '--path.rootfs=/host'
       - '--collector.textfile.directory=/backup_data'
+      - '--web.listen-address=:9101'
     network_mode: host
     pid: host
     restart: unless-stopped

--- a/prometheus/prometheus.example.yml
+++ b/prometheus/prometheus.example.yml
@@ -27,4 +27,4 @@ scrape_configs:
     scrape_interval: 30s
     static_configs:
       # note: localhost because node_exporter service uses network_mode=host
-      - targets: ['%SUBSTITUTE_HOST_NETWORK_IP%:9100']
+      - targets: ['%SUBSTITUTE_HOST_NETWORK_IP%:9101']


### PR DESCRIPTION
# MaRDI Pull Request

issue #164 workaround

**Changes**:
- make node exporter port 9101 instead of 9100

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
