### PR TITLE
temporarily disable Nuke extension #180

### DIFF
--- a/mediawiki/LocalSettings.d/Nuke.php
+++ b/mediawiki/LocalSettings.d/Nuke.php
@@ -2,4 +2,4 @@
 
 // https://www.mediawiki.org/wiki/Extension:Nuke
 ## Nuke Configuration
-wfLoadExtension( 'Nuke' );
+# wfLoadExtension( 'Nuke' );


### PR DESCRIPTION
# MaRDI Pull Request

#180 https://github.com/MaRDI4NFDI/docker-wikibase/issues/22

**Changes**:
- disable nuke extension 

**Note**: revert this change when mediawiki dockerhub image was updated to 1.35.6 https://hub.docker.com/_/mediawiki?tab=tags&page=1&name=1.35

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
