### PR TITLE
re-enable Nuke extension

### DIFF
--- a/mediawiki/LocalSettings.d/Nuke.php
+++ b/mediawiki/LocalSettings.d/Nuke.php
@@ -2,4 +2,4 @@
 
 // https://www.mediawiki.org/wiki/Extension:Nuke
 ## Nuke Configuration
-# wfLoadExtension( 'Nuke' );
+wfLoadExtension( 'Nuke' );


### PR DESCRIPTION
# MaRDI Pull Request

mediawiki 1.35.6 was released already, so the Nuke extension can be enabled again
#181 #180 
Note that https://github.com/MaRDI4NFDI/docker-wikibase/pull/24 must be merged and the package be published before this can pass

**Changes**:
- enable Nuke


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
