### PR TITLE
delete doublequotes from email cfg

### DIFF
--- a/grafana/grafana.template.ini
+++ b/grafana/grafana.template.ini
@@ -9,6 +9,6 @@ cert_file =
 key_file =
 skip_verify = false
 from_address = $GF_MAIL_FROMADDRESS
-from_name = "$GF_MAIL_FROMNAME"
+from_name = $GF_MAIL_FROMNAME
 ehlo_identity =
 startTLS_policy =


### PR DESCRIPTION
# MaRDI Pull Request

just a tiny fix after alert notification test, delete the unnecessary double quotes around the sender name from the config file


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
