### PR TITLE
introduce env var to toggle automatic backups

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,7 @@ services:
       DB_PASS: ${DB_PASS}
       BACKUP_SCHEDULE: '15 4 * * *'
       KEEP_DAYS: ${KEEP_DAYS:-30}
+      BACKUP_CRON_ENABLE: ${BACKUP_CRON_ENABLE:-true}
     entrypoint: "/app/start.sh"
 
   reverse-proxy:

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -63,9 +63,11 @@ PROMETHEUS_PORT=9090
 # Host network IP for system metrics exporter 'node_exporter'
 HOST_NETWORK_IP=set-host-network-ip
 
-## MySQL Backup
+## MySQL/XML Backup
 BACKUP_SCHEDULE='15 5 * * *' # every day at 05:15
 BACKUP_DIR=./backup
+# Backup toggle -- set true to enable automatic backups via cronjob; if false no automatic backups will be carried out (e.g., for local builds)
+BACKUP_CRON_ENABLE=true
 
 ## GRAFANA SETTINGS
 # Email settings to send alerts per mail from given provider


### PR DESCRIPTION
# MaRDI Pull Request

per https://github.com/MaRDI4NFDI/T5ProjectManagement/issues/68

in combination with https://github.com/MaRDI4NFDI/docker-backup/pull/17

**Changes**:
- introduce new env var `$BACKUP_CRON_ENABLE` to enable/disable automatic backups via crontab (Default: true)

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
