### PR TITLE
Grant createaccount permissions to users

### DIFF
--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -27,6 +27,7 @@
 
 # Prevent new user registrations except by sysops
 $wgGroupPermissions['*']['createaccount'] = false;
+$wgGroupPermissions['user']['createaccount'] = false;
 
 # Restrict anonymous editing
 $wgGroupPermissions['*']['edit'] = false;

--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -27,7 +27,7 @@
 
 # Prevent new user registrations except by sysops
 $wgGroupPermissions['*']['createaccount'] = false;
-$wgGroupPermissions['user']['createaccount'] = false;
+$wgGroupPermissions['user']['createaccount'] = true;
 
 # Restrict anonymous editing
 $wgGroupPermissions['*']['edit'] = false;


### PR DESCRIPTION
While we don't want to allow anonymous accounts, we want to give users permission to create other users.

Request from @lkastner to create accounts for T1 users. 