### PR TITLE
mysql metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,8 @@ x-extra-variables: &wikibase_extra_variables
 
 services:
   wikibase:
-    image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
+    # image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
+    image: wikibase_test
     container_name: mardi-wikibase
     links:
       - mysql
@@ -53,7 +54,8 @@ services:
       - traefik.http.routers.service-wikibase.tls.certResolver=le
 
   wikibase_jobrunner:
-    image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
+    # image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
+    image: wikibase_test
     entrypoint: /bin/bash
     command:  /jobrunner-entrypoint.sh
     links:
@@ -88,7 +90,7 @@ services:
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
     networks:
       default:
-        aliases:
+        aliases
          - mysql.svc
 
   backup:
@@ -361,6 +363,16 @@ services:
     volumes:
       - '/:/host:ro,rslave'
       - '${BACKUP_DIR:-./backup}:/backup_data:ro'
+
+  mysqld_exporter:
+    image: prom/mysqld-exporter:latest
+    container_name: mysqld_exporter
+    depends_on:
+      - mysql
+    command:
+      - '--web.listen-address=:9104'
+    environment:
+      DATA_SOURCE_NAME: "exporter:${MYSQLD_EXPORTER_PASS}@(mysql.svc:3306)/"
     
   # Watchtower provides automatic updates for all containers
   # see https://containrrr.github.io/watchtower/arguments/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,7 @@ x-extra-variables: &wikibase_extra_variables
 
 services:
   wikibase:
-    # image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
-    image: wikibase_test
+    image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
     container_name: mardi-wikibase
     links:
       - mysql
@@ -54,8 +53,7 @@ services:
       - traefik.http.routers.service-wikibase.tls.certResolver=le
 
   wikibase_jobrunner:
-    # image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
-    image: wikibase_test
+    image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
     entrypoint: /bin/bash
     command:  /jobrunner-entrypoint.sh
     links:
@@ -90,7 +88,7 @@ services:
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
     networks:
       default:
-        aliases
+        aliases:
          - mysql.svc
 
   backup:

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -62,6 +62,8 @@ GRAFANA_PORT=3000
 PROMETHEUS_PORT=9090
 # Host network IP for system metrics exporter 'node_exporter'
 HOST_NETWORK_IP=set-host-network-ip
+# mysqld_exporter gets a DB user "exporter" with password:
+MYSQLD_EXPORTER_PASS=set-secret-pw
 
 ## MySQL/XML Backup
 BACKUP_SCHEDULE='15 5 * * *' # every day at 05:15

--- a/prometheus/prometheus.template.yml
+++ b/prometheus/prometheus.template.yml
@@ -31,4 +31,4 @@ scrape_configs:
       - targets: ['$HOST_NETWORK_IP:9101']
   - job_name: mysql
     static_configs:
-      - targets: ['mysqld-exporter:9104']
+      - targets: ['mysqld_exporter:9104']

--- a/prometheus/prometheus.template.yml
+++ b/prometheus/prometheus.template.yml
@@ -29,3 +29,6 @@ scrape_configs:
       # note: localhost because node_exporter service uses network_mode=host
       # env var needs to be replaced with envsubst or sed by setup script
       - targets: ['$HOST_NETWORK_IP:9101']
+  - job_name: mysql
+    static_configs:
+      - targets: ['mysqld-exporter:9104']


### PR DESCRIPTION
# MaRDI Pull Request

Provide prometheus [mysqld_exporter](https://github.com/prometheus/mysqld_exporter) to create mysql metrics.
part of #189 

**Changes**:
- add & setup mysqld_exporter container

**TODO**:
- a mysql user "exporter" with special grants needs to be created. **required: admin password!**
 (see https://registry.hub.docker.com/r/prom/mysqld-exporter/ / https://github.com/prometheus/mysqld_exporter)

`docker exec -ti mardi-mysql mysql -uroot -p`
```mysql
CREATE USER 'exporter'@'%' IDENTIFIED BY 'secret-password' WITH MAX_USER_CONNECTIONS 3;
GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'exporter'@'%';
```

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
