### PR TITLE
enable watchtower metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,7 @@ services:
       TRAEFIK_USER: ${TRAEFIK_USER}
       TRAEFIK_PW: ${TRAEFIK_PW}
       HOST_NETWORK_IP: ${HOST_NETWORK_IP}
+      WATCHTOWER_API_TOKEN: ${WATCHTOWER_API_TOKEN}
 
   prometheus:
     image: prom/prometheus
@@ -362,7 +363,7 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --include-stopped --revive-stopped --schedule "0 0 1 * * *"
+    command: --include-stopped --revive-stopped --schedule "0 0 1 * * *" --http-api-metrics --http-api-token ${WATCHTOWER_API_TOKEN}
     restart: always
     
 volumes:

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -77,5 +77,7 @@ GF_MAIL_PW=set-email-password
 GF_MAIL_FROMADDRESS=set-login@example.com
 GF_MAIL_FROMNAME=set-sender-name
 
+## Watchtower settings
+WATCHTOWER_API_TOKEN=set-token
 ## Formulasearch
 ENABLE_REST_INSERTIONS=false

--- a/prometheus/prometheus.template.yml
+++ b/prometheus/prometheus.template.yml
@@ -29,3 +29,8 @@ scrape_configs:
       # note: localhost because node_exporter service uses network_mode=host
       # env var needs to be replaced with envsubst or sed by setup script
       - targets: ['$HOST_NETWORK_IP:9101']
+  - job_name: watchtower
+    metrics_path: /v1/metrics
+    bearer_token: $WATCHTOWER_API_TOKEN
+    static_configs:
+      - targets: ['watchtower:8080']


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- enable watchtower metrics api
- setup prometheus to scrape watchtower @ port 8080
- set API token in .env on production

**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
