### PR TITLE
Deactivate display errors

### DIFF
--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -23,7 +23,7 @@
 /*******************************/
 /* Disable UI error-reporting  */
 /*******************************/
-#ini_set( 'display_errors', 1 );
+ini_set( 'display_errors', '0' );
 
 # Prevent new user registrations except by sysops
 $wgGroupPermissions['*']['createaccount'] = false;


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- I find this a better solution to https://github.com/MaRDI4NFDI/portal-compose/issues/219. 'display_errors' should by default be set to 0.
- I reverted the previous change in https://github.com/MaRDI4NFDI/docker-wikibase/pull/35, because changes in LocalSettings.mardi.template are not automatically deployed (see https://github.com/MaRDI4NFDI/docker-wikibase/pull/33)


**Instructions for PR review**:
- [X] Conceptual Review (Logic etc...) 
- [X] Code Review (Review your implementation) 
- [X] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [X] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [X] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
