### PR TITLE
remove mistakenly added traefik-pass file again

### DIFF
--- a/prometheus/traefik-pass
+++ b/prometheus/traefik-pass
@@ -1,1 +1,0 @@
-change-this-password


### PR DESCRIPTION
# MaRDI Pull Request

previously deleted traefik-pass was mistakenly added again here: https://github.com/MaRDI4NFDI/portal-compose/pull/159#discussion_r883406314

this PR deletes it.

ref #232 

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
