### PR TITLE
replace single by double quotes from backup cron pattern

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
-      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-'15 4 * * *'}
+      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-"15 4 * * *"}
       KEEP_DAYS: ${KEEP_DAYS:-30}
       BACKUP_CRON_ENABLE: ${BACKUP_CRON_ENABLE:-true}
     entrypoint: "/app/start.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       DB_NAME: ${DB_NAME}
       DB_USER: ${DB_USER}
       DB_PASS: ${DB_PASS}
-      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE:-"15 4 * * *"}
+      BACKUP_SCHEDULE: ${BACKUP_SCHEDULE}
       KEEP_DAYS: ${KEEP_DAYS:-30}
       BACKUP_CRON_ENABLE: ${BACKUP_CRON_ENABLE:-true}
     entrypoint: "/app/start.sh"

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -70,13 +70,13 @@ HOST_NETWORK_IP=set-host-network-ip
 
 ## MySQL/XML Backup
 # Backup cron pattern (every day, 4:15 AM)
-BACKUP_SCHEDULE="15 4 * * *"
+BACKUP_SCHEDULE=15 4 * * *
 BACKUP_DIR=./backup
 # Backup toggle -- set true to enable automatic backups via cronjob; if false no automatic backups will be carried out (e.g., for local builds)
 BACKUP_CRON_ENABLE=true
 
 ## Docker importer (every day, 1:30)
-IMPORT_SCHEDULE='30 1 * * *' 
+IMPORT_SCHEDULE=30 1 * * *
 # Import toggle -- set true to enable automatic backups via cronjob; if false no automatic import will be executed
 IMPORTER_CRON_ENABLE=false
 

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -70,7 +70,7 @@ HOST_NETWORK_IP=set-host-network-ip
 
 ## MySQL/XML Backup
 # Backup cron pattern (every day, 4:15 AM)
-BACKUP_SCHEDULE='15 4 * * *'
+BACKUP_SCHEDULE="15 4 * * *"
 BACKUP_DIR=./backup
 # Backup toggle -- set true to enable automatic backups via cronjob; if false no automatic backups will be carried out (e.g., for local builds)
 BACKUP_CRON_ENABLE=true


### PR DESCRIPTION
# MaRDI Pull Request

inside the mardi-backup container on production, the cron pattern created by this line https://github.com/MaRDI4NFDI/docker-backup/blob/f1a62df3ccb7fe21ecc66349cfe15f76e8f064e3/start.sh#L42, includes the single quotes around the cron pattern in $BACKUP_SCHEDULE. (This does not happen in the same container on my local system.)

Solution: delete quotes as they are not required

NOTE: environment file was modified accordlingly

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
