### PR TITLE
Disable Watchtower automatic pulling of images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -408,7 +408,8 @@ services:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --include-stopped --revive-stopped --schedule "0 0 1 * * *" --http-api-metrics --http-api-token ${WATCHTOWER_API_TOKEN}
+    # FIX (13/06/22): --monitor-only will not pull new images, s.t. faulty wikibase image is not pulled
+    command: --monitor-only --revive-stopped --schedule "0 0 1 * * *" --http-api-metrics --http-api-token ${WATCHTOWER_API_TOKEN}
     restart: always
 
 volumes:


### PR DESCRIPTION
Apparently the current wikibase image has errors. Set watchtower to "monitor only" mode, such that the faulty image is not pulled.

Must be undone when the issue is fixed!

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
