### PR TITLE
Update Elasticsearch and WDQS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,7 +183,7 @@ services:
       - traefik.http.middlewares.auth.basicauth.users=mardi:$$2y$$05$$Ubl1B.74bDJkpGHXZ6Y4Xuq8lSx88bi51bmE85/VYf1nQizfKKuH.
 
   elasticsearch:
-    image: "${ELASTICSEARCH_IMAGE_NAME:-wikibase/elasticsearch:6.5.4-wmde.2}"
+    image: "${ELASTICSEARCH_IMAGE_NAME:-wikibase/elasticsearch:6.8.23-wmde.6}"
     restart: unless-stopped
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
@@ -193,7 +193,7 @@ services:
          - elasticsearch.svc
     environment:
       discovery.type: single-node
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m -Dlog4j2.formatMsgNoLookups=true"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
 
   formulasearch:
     image: ghcr.io/mardi4nfdi/formulasearch:main
@@ -214,7 +214,7 @@ services:
       - ${BACKUP_DIR:-./backup}:/data
 
   wdqs-frontend:
-    image: "${WDQS_FRONTEND_IMAGE_NAME:-wikibase/wdqs-frontend:wmde.2}"
+    image: "${WDQS_FRONTEND_IMAGE_NAME:-wikibase/wdqs-frontend:wmde.6}"
     container_name: mardi-wdqs-frontend
     restart: unless-stopped
     depends_on:
@@ -234,7 +234,7 @@ services:
       - traefik.http.routers.service-wdqs-frontend.tls.certResolver=le
 
   wdqs:
-    image: "${WDQS_IMAGE_NAME:-wikibase/wdqs:0.3.40-wmde.2}"
+    image: "${WDQS_IMAGE_NAME:-wikibase/wdqs:0.3.40-wmde.6}"
     restart: unless-stopped
     command: /runBlazegraph.sh
     volumes:
@@ -252,7 +252,7 @@ services:
       - 9999
 
   wdqs-proxy:
-    image: "${WDQS_PROXY_IMAGE_NAME:-wikibase/wdqs-proxy:wmde.2}"
+    image: "${WDQS_PROXY_IMAGE_NAME:-wikibase/wdqs-proxy:wmde.6}"
     restart: unless-stopped
     environment:
       - PROXY_PASS_HOST=wdqs.svc:9999
@@ -264,7 +264,7 @@ services:
          - wdqs-proxy.svc
 
   wdqs-updater:
-    image: "${WDQS_IMAGE_NAME:-wikibase/wdqs:0.3.40-wmde.2}"
+    image: "${WDQS_IMAGE_NAME:-wikibase/wdqs:0.3.40-wmde.6}"
     restart: unless-stopped
     command: /runUpdate.sh
     depends_on:

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -2,11 +2,11 @@
 # WARNING: Do not add comments on the same line as env vars, as in some environments they will be included in the var!
 
 ## Image Configuration
-WDQS_IMAGE_NAME=wikibase/wdqs:0.3.40-wmde.2
-WDQS_FRONTEND_IMAGE_NAME=wikibase/wdqs-frontend:wmde.2
-ELASTICSEARCH_IMAGE_NAME=wikibase/elasticsearch:6.5.4-wmde.2
+WDQS_IMAGE_NAME=wikibase/wdqs:0.3.40-wmde.6
+WDQS_FRONTEND_IMAGE_NAME=wikibase/wdqs-frontend:wmde.6
+ELASTICSEARCH_IMAGE_NAME=wikibase/elasticsearch:6.8.23-wmde.6
 QUICKSTATEMENTS_IMAGE_NAME=ghcr.io/mardi4nfdi/docker-quickstatements:master
-WDQS_PROXY_IMAGE_NAME=wikibase/wdqs-proxy:wmde.2
+WDQS_PROXY_IMAGE_NAME=wikibase/wdqs-proxy:wmde.6
 MYSQL_IMAGE_NAME=mariadb:10.3
 BACKUP_IMAGE_NAME=ghcr.io/mardi4nfdi/docker-backup:main
 


### PR DESCRIPTION
Use wmde.6 builds to match recent update of docker-wikibase.
This fixes https://github.com/MaRDI4NFDI/docker-wikibase/issues/46.

elasticsearch 6.5.4-wmde.2 -> 6.8.23-wmde.6
wdqs-* wmde.2 -> wmde.6

NOTE: the elasticsearch ES_JAVA_OPT `-Dlog4j2.formatMsgNoLookups=true` can probably be dropped since the security issue should be fixed in the newer version: https://discuss.elastic.co/t/apache-log4j2-remote-code-execution-rce-vulnerability-cve-2021-44228-esa-2021-31/291476#elasticsearch-11


**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
