### PR TITLE
Define required settings for Math Popups

### DIFF
--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -143,5 +143,14 @@ $wgMathSearchBaseXBackendUrl="http://formulasearch:1985/basex/";
 $wgMathFullRestbaseURL = 'https://wikimedia.org/api/rest_';
 $wgMathMathMLUrl = 'https://mathoid-beta.wmflabs.org';
 
+#popups for math
+
+$wgMathWikibasePropertyIdDefiningFormula = "P14";
+$wgMathWikibasePropertyIdHasPart = "P4";
+$wgMathWikibasePropertyIdInDefiningFormula = "P1";
+$wgMathWikibasePropertyIdQuantitySymbol = "P1";
+$wgMathWikibasePropertyIdSymbolRepresents = "P1";
+
+
 # increase memory limit
 ini_set('memory_limit', '2G');

--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -140,6 +140,7 @@ $wgVisualEditorRebaserURL = 'http://localhost:8081';
 # Settings for MathSearch extension.
 $wgMathSearchBaseXBackendUrl="http://formulasearch:1985/basex/";
 
+# Settings for Math-Exension
 $wgMathFullRestbaseURL = 'https://wikimedia.org/api/rest_';
 $wgMathMathMLUrl = 'https://mathoid-beta.wmflabs.org';
 

--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -145,7 +145,6 @@ $wgMathFullRestbaseURL = 'https://wikimedia.org/api/rest_';
 $wgMathMathMLUrl = 'https://mathoid-beta.wmflabs.org';
 
 #popups for math
-
 $wgMathWikibasePropertyIdDefiningFormula = "P14";
 $wgMathWikibasePropertyIdHasPart = "P4";
 

--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -147,10 +147,6 @@ $wgMathMathMLUrl = 'https://mathoid-beta.wmflabs.org';
 
 $wgMathWikibasePropertyIdDefiningFormula = "P14";
 $wgMathWikibasePropertyIdHasPart = "P4";
-$wgMathWikibasePropertyIdInDefiningFormula = "P1";
-$wgMathWikibasePropertyIdQuantitySymbol = "P1";
-$wgMathWikibasePropertyIdSymbolRepresents = "P1";
-
 
 # increase memory limit
 ini_set('memory_limit', '2G');


### PR DESCRIPTION
Currently 

https://portal.mardi4nfdi.de/w/index.php?title=Special:MathWikibase&qid=Q8376

shows a bug. However, it should show a special page. This is due to unset properties. After these properties are defined the error should vanish.