### PR TITLE
Fix Searchtest.py add Vector 2022 skin

### DIFF
--- a/mediawiki/LocalSettings.d/Skins.php
+++ b/mediawiki/LocalSettings.d/Skins.php
@@ -1,4 +1,7 @@
 <?php
 
-wfLoadSkin('Timeless');
-$wgDefaultSkin = 'Timeless';
+wfLoadSkin( 'Vector' );
+$wgDefaultSkin = 'vector-2022';
+
+#wfLoadSkin('Timeless');
+#$wgDefaultSkin = 'Timeless';

--- a/test/SearchTest.py
+++ b/test/SearchTest.py
@@ -9,6 +9,8 @@ from MediawikiTest import MediawikiBase
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.by import By
+import time
 
 class SearchTest(MediawikiBase):
     def test_01(self):
@@ -16,10 +18,19 @@ class SearchTest(MediawikiBase):
         home_url = "http://mardi-wikibase"
         self.loadURL(home_url)
         current_url = self.driver.current_url
-        self.getElementById('searchInput').clear()
-        self.getElementById('searchInput').send_keys("boe")
-        self.getElementById('searchInput').send_keys(Keys.ENTER)
+
+        vue = self.driver.find_elements(By.XPATH,"//div[@id='p-search']/a")
+        if vue:
+            vue[0].click()
+            time.sleep(2)
+            search_field = self.getElementByXPath("//div[@id='p-search']/descendant::input[1]")
+        else:
+            search_field = self.getElementById('searchInput')
+
+        search_field.clear()
+        search_field.send_keys("boe")
+        search_field.send_keys(Keys.ENTER)
         # wait for search to load
         WebDriverWait(self.driver, 5).until(EC.url_changes(current_url))
         search_results = self.getElementById('mw-content-text').text
-        self.assertFalse('An error has occurred while searching' in search_results, 'Error while searching')
+        self.assertFalse('An error has occurred while searching' in search_results, 'Error while searching')        


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Fixes the selenium SearchTest.py so that Vue.js components can be detected. 
- SearchTest failed because Vector 2022 skin uses Vue components (see https://github.com/MaRDI4NFDI/portal-compose/issues/284)
-  Vector 2022 is again activated in substitution of Timeless.

**Instructions for PR review**:
- [X] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [X] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [X] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
