### PR TITLE
Update traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
 
   reverse-proxy:
     restart: always
-    image: traefik:v2.5
+    image: traefik:v2.8
     ports:
       - 443:443 # HTTPS port
       - 80:80 # HTTP port


### PR DESCRIPTION
Currently, traefik can not renew or issue new TLS certificates.

# MaRDI Pull Request

**Changes**:
- Update traefik version to latest release

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
