### PR TITLE
fix GoAccess using CRON and static reports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -423,7 +423,7 @@ services:
       - apache_logs:/srv/log:ro
       - apache_reports:/srv/reports
       - goaccess_db:/srv/data
-      - ./goaccess/goaccess.conf:/etc/goaccess.conf
+      - ./goaccess/goaccess.conf:/etc/goaccess/goaccess.conf
       - ./goaccess/GeoLite2-City.mmdb:/srv/geoip/GeoLite2-City.mmdb
     labels:
       - traefik.enable=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,6 @@ services:
     ports:
       - 443:443 # HTTPS port
       - 80:80 # HTTP port
-      # - 7890:7890 # goaccess websocket
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
@@ -410,48 +409,24 @@ services:
       - '${BACKUP_DIR:-./backup}:/backup_data:ro'
 
   goaccess:
-    image: allinurl/goaccess
+    image: "ghcr.io/mardi4nfdi/docker-goaccess-cron:main"
     container_name: goaccess
-    depends_on:
-      - traefik-certs-dumper
-    restart: always
+    restart: unless-stopped
     command:
-      - '--log-file=/srv/log/access.log'
-      - '--output=/srv/reports/index.html'
-      - '--log-format=COMBINED'
-      - '--real-time-html'
-      # - '--no-global-config'
-      - '--tz=Europe/Berlin'
-      - '--anonymize-ip'
-      # - '--config-file=/etc/goaccess.conf'
-      - '--geoip-database=/srv/geoip/GeoLite2-City.mmdb'
-      - '--db-path=/srv/data'
-      - '--ssl-cert=/letsencrypt/certs/certs/stats.portal.mardi4nfdi.de.crt'
-      - '--ssl-key=/letsencrypt/certs/private/stats.portal.mardi4nfdi.de.key'
-      # - '--restore'
-      # - '--persist'
-    # expose:
-    #   - 7890
-    ports:
-      - 7890:7890
-    networks:
-      default:
-        aliases:
-         - goaccess.svc
+      - --log-file=/srv/log/access.log
+      - --output=/srv/reports/index.html
+      - --geoip-database=/srv/geoip/GeoLite2-City.mmdb
+      - --db-path=/srv/data
+    environment:
+      - GOACCESS_SCHEDULE=${GOACCESS_SCHEDULE:-0 0 * * *}
     volumes:
       - apache_logs:/srv/log:ro
       - apache_reports:/srv/reports
       - goaccess_db:/srv/data
-      # - ./goaccess/goaccess.conf:/etc/goaccess.conf
+      - ./goaccess/goaccess.conf:/etc/goaccess.conf
       - ./goaccess/GeoLite2-City.mmdb:/srv/geoip/GeoLite2-City.mmdb
-      - traefik-letsencrypt:/letsencrypt:ro
-    # labels:
-    #   - traefik.http.routers.goaccess.rule=Host(`stats.portal.mardi4nfdi.de`) # && PathPrefix(`/ws`)
-    #   - traefik.http.routers.goaccess.entrypoints=wss
-    #   - traefik.http.routers.goaccess.tls.certResolver=le
-    #   - traefik.http.routers.goaccess.middlewares=sslheader
-    #   - traefik.http.middlewares.sslheader.headers.customRequestHeaders.X-Forwarded-Proto=https
-    #   - traefik.http.services.goaccess-portal-compose.loadbalancer.server.port=7890
+    labels:
+      - traefik.enable=false
 
   nginx:
     image: nginx
@@ -460,23 +435,13 @@ services:
       - goaccess
     volumes:
       - apache_reports:/usr/share/nginx/html
-    # ports:
-    #   - 8000:80
-    # networks:
-    #   default:
-    #     aliases:
-    #      - nginx.svc
+    ports:
+      - 8000:80
     labels:
       - traefik.http.routers.nginx.rule=Host(`stats.portal.mardi4nfdi.de`)
       - traefik.http.routers.nginx.entrypoints=websecure
       - traefik.http.routers.nginx.tls.certResolver=le
       - traefik.http.routers.nginx.middlewares=auth
-
-  traefik-certs-dumper:
-    image: ldez/traefik-certs-dumper:v2.8.1
-    entrypoint: sh -c 'apk add jq ; while ! [ -e /data/acme.json ] || ! [ `jq ".[] | .Certificates | length" /data/acme.json` != 0 ]; do sleep 1 ; done && traefik-certs-dumper file --version v2 --watch --source /data/acme.json --dest /data/certs'
-    volumes:
-      - traefik-letsencrypt:/data
 
   # Watchtower provides automatic updates for all containers
   # see https://containrrr.github.io/watchtower/arguments/

--- a/goaccess/README.md
+++ b/goaccess/README.md
@@ -2,6 +2,7 @@
 
 [GoAccess](goaccess.io) is an opensource log analyzer, set up in `docker-compose.yml` to
 parse the mediawiki apache log `/var/log/apache2/access.log`.
+The resulting report can be served with a webserver, e.g. nginx.
 
 ## Requirements
 
@@ -24,9 +25,3 @@ The setup contained in `docker-compose.yml` and `goaccess/goaccess.conf` of
 In order to resolve IP geo locations, download the free database `GeoLite2 City` from https://www.maxmind.com/en/accounts/758058/geoip/downloads.
 An account was already registered with our MaRDI4NFDI groupware email account.
 Extract the file `GeoLite2-City.mmdb` to the directory `./goaccess/`.
-
-
-## TODO
-
-- logrotation for access.log
-

--- a/goaccess/goaccess.conf
+++ b/goaccess/goaccess.conf
@@ -1,1 +1,7 @@
-# put settings here
+# GoAccess settings that are independent of docker-compose config
+# cf. https://raw.githubusercontent.com/allinurl/goaccess/master/config/goaccess.conf
+log-format COMBINED
+tz Europe/Berlin
+anonymize-ip true
+restore true
+persist true

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -97,6 +97,10 @@ FS_CRON_UPDATE_FORMULAE=0 0 1 * * *
 FS_CRON_ENABLED=true
 FS_ALWAYS_EXPORT=false
 
+## GOACCESS
+# cron schedule
+GOACCESS_SCHEDULE=0 0 * * *
+
 ## Deployment environment ('prod' or 'local')
 ## Delete /shared/LocalSettings.php and restart mardi-wikibase to deploy changes to this flag.
 DEPLOYMENT_ENV=local

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -20,8 +20,6 @@ entryPoints:
           scheme: https
   metrics:
     address: :8082
-  wss:
-    address: :7890
 
 metrics:
   prometheus:


### PR DESCRIPTION
# MaRDI Pull Request

Implements goaccess with static reports and cron, since websocket-based real time html reports could not get to work in time.

for future reference here are my questions on the goaccess issue tracker and in the traefik forum:
https://github.com/allinurl/goaccess/issues/2369
https://community.traefik.io/t/cannot-connect-to-secure-websocket-goaccess/15550

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
