### PR TITLE
use uncompressed log.1 due to delaycompress

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,8 @@ x-extra-variables: &wikibase_extra_variables
 
 services:
   wikibase:
-    image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
+    image: wikibase_logrotate
+    # image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
     container_name: mardi-wikibase
     links:
       - mysql
@@ -413,7 +414,8 @@ services:
     container_name: goaccess
     restart: unless-stopped
     command:
-      - --log-file=/srv/log/access.log
+      - /srv/log/access.log
+      - /srv/log/access.log.1
       - --output=/srv/reports/index.html
       - --geoip-database=/srv/geoip/GeoLite2-City.mmdb
       - --db-path=/srv/data


### PR DESCRIPTION
# MaRDI Pull Request

fix small error: logrotate option delaycompress (cf. man logrotate) compresses access.log.1 on next rotation, hence goaccess should look for uncompressed file

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
