### PR TITLE
goaccess: parse traefik logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -426,7 +426,7 @@ services:
       - GOACCESS_SCHEDULE=${GOACCESS_SCHEDULE:-0 0 * * *}
     volumes:
       - ./traefik-log:/srv/log:ro
-      - apache_reports:/srv/reports
+      - goaccess_report:/srv/reports
       - goaccess_db:/srv/data
       - ./goaccess/goaccess.conf:/etc/goaccess/goaccess.conf
       - ./goaccess/GeoLite2-City.mmdb:/srv/geoip/GeoLite2-City.mmdb
@@ -439,7 +439,7 @@ services:
     depends_on:
       - goaccess
     volumes:
-      - apache_reports:/usr/share/nginx/html
+      - goaccess_report:/usr/share/nginx/html
     labels:
       - traefik.http.routers.nginx.rule=Host(`stats.portal.mardi4nfdi.de`)
       - traefik.http.routers.nginx.entrypoints=websecure
@@ -471,5 +471,5 @@ volumes:
   formulasearch_harvests:
   shared_mediawiki_images:
   apache_logs:
-  apache_reports:
+  goaccess_report:
   goaccess_db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,7 @@ services:
   reverse-proxy:
     restart: always
     image: traefik:v2.8
+    container_name: reverse-proxy
     ports:
       - 443:443 # HTTPS port
       - 80:80 # HTTP port
@@ -173,7 +174,7 @@ services:
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/conf/:/traefik-conf/:ro
       - traefik-letsencrypt:/letsencrypt # Persistent file for ACME Setup (Certificate Store)
-      - traefik-log:/data/log # Persistent file for logging
+      - ./traefik-log:/data/log # Persistent file for logging
     networks:
       - default
     labels:
@@ -183,13 +184,6 @@ services:
       - traefik.http.routers.dashboard.service=api@internal
       - traefik.http.routers.dashboard.middlewares=auth
       - traefik.http.middlewares.auth.basicauth.users=mardi:$$2y$$05$$Ubl1B.74bDJkpGHXZ6Y4Xuq8lSx88bi51bmE85/VYf1nQizfKKuH.
-
-  logrotate:
-    restart: always
-    image: ghcr.io/mardi4nfdi/docker-logrotate:main
-    container_name: logrotate
-    volumes:
-      - traefik-log:/var/log/traefik
 
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_NAME:-wikibase/elasticsearch:6.8.23-wmde.6}"
@@ -431,7 +425,7 @@ services:
     environment:
       - GOACCESS_SCHEDULE=${GOACCESS_SCHEDULE:-0 0 * * *}
     volumes:
-      - traefik-log:/srv/log:ro
+      - ./traefik-log:/srv/log:ro
       - apache_reports:/srv/reports
       - goaccess_db:/srv/data
       - ./goaccess/goaccess.conf:/etc/goaccess/goaccess.conf
@@ -465,7 +459,7 @@ volumes:
   shared_mardi_wikibase:
   mediawiki-mysql-data:
   mediawiki-mongo-data:
-  traefik-log:
+  # traefik-log:
   traefik-letsencrypt:
   LocalSettings:
   query-service-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,8 @@ x-extra-variables: &wikibase_extra_variables
 
 services:
   wikibase:
-    image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
+    image: wikibase_logrotate
+    # image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
     container_name: mardi-wikibase
     links:
       - mysql
@@ -413,7 +414,8 @@ services:
     container_name: goaccess
     restart: unless-stopped
     command:
-      - --log-file=/srv/log/access.log
+      - /srv/log/access.log
+      - /srv/log/access.log.1
       - --output=/srv/reports/index.html
       - --geoip-database=/srv/geoip/GeoLite2-City.mmdb
       - --db-path=/srv/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,7 @@ x-extra-variables: &wikibase_extra_variables
 
 services:
   wikibase:
-    image: wikibase_logrotate
-    # image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
+    image: "ghcr.io/mardi4nfdi/docker-wikibase:main"
     container_name: mardi-wikibase
     links:
       - mysql
@@ -184,6 +183,13 @@ services:
       - traefik.http.routers.dashboard.service=api@internal
       - traefik.http.routers.dashboard.middlewares=auth
       - traefik.http.middlewares.auth.basicauth.users=mardi:$$2y$$05$$Ubl1B.74bDJkpGHXZ6Y4Xuq8lSx88bi51bmE85/VYf1nQizfKKuH.
+
+  logrotate:
+    restart: always
+    image: ghcr.io/mardi4nfdi/docker-logrotate:main
+    container_name: logrotate
+    volumes:
+      - traefik-log:/var/log/traefik
 
   elasticsearch:
     image: "${ELASTICSEARCH_IMAGE_NAME:-wikibase/elasticsearch:6.8.23-wmde.6}"
@@ -415,14 +421,17 @@ services:
     restart: unless-stopped
     command:
       - /srv/log/access.log
-      - /srv/log/access.log.1
+      - /srv/log/access.log.1.gz
       - --output=/srv/reports/index.html
       - --geoip-database=/srv/geoip/GeoLite2-City.mmdb
       - --db-path=/srv/data
+      # - --log-format='%h %^[%d:%t %^] "%r" %s %b "%R" "%u" %Lm'
+      # - --date-format=%d/%b/%Y
+      # - --time-format=%T
     environment:
       - GOACCESS_SCHEDULE=${GOACCESS_SCHEDULE:-0 0 * * *}
     volumes:
-      - apache_logs:/srv/log:ro
+      - traefik-log:/srv/log:ro
       - apache_reports:/srv/reports
       - goaccess_db:/srv/data
       - ./goaccess/goaccess.conf:/etc/goaccess/goaccess.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -421,13 +421,13 @@ services:
     restart: unless-stopped
     command:
       - /srv/log/access.log
-      - /srv/log/access.log.1.gz
+      - /srv/log/access.log.1
       - --output=/srv/reports/index.html
       - --geoip-database=/srv/geoip/GeoLite2-City.mmdb
       - --db-path=/srv/data
-      # - --log-format='%h %^[%d:%t %^] "%r" %s %b "%R" "%u" %Lm'
-      # - --date-format=%d/%b/%Y
-      # - --time-format=%T
+      - --log-format='%h %^[%d:%t %^] "%r" %s %b "%R" "%u" %Lm'
+      - --date-format=%d/%b/%Y
+      - --time-format=%T
     environment:
       - GOACCESS_SCHEDULE=${GOACCESS_SCHEDULE:-0 0 * * *}
     volumes:
@@ -446,8 +446,6 @@ services:
       - goaccess
     volumes:
       - apache_reports:/usr/share/nginx/html
-    ports:
-      - 8000:80
     labels:
       - traefik.http.routers.nginx.rule=Host(`stats.portal.mardi4nfdi.de`)
       - traefik.http.routers.nginx.entrypoints=websecure

--- a/goaccess/README.md
+++ b/goaccess/README.md
@@ -1,26 +1,32 @@
 # GoAccess setup
 
 [GoAccess](goaccess.io) is an opensource log analyzer, set up in `docker-compose.yml` to
-parse the mediawiki apache log `/var/log/apache2/access.log`.
-The resulting report can be served with a webserver, e.g. nginx.
+parse the `access.log` of the reverse proxy traefik.
+The resulting report is served (here) with a nginx webserver.
 
-## Requirements
+We use a custom docker image (https://github.com/MaRDI4NFDI/docker-goaccess-cron), running goaccess via cron.
+The configuration contained in `docker-compose.yml` and `goaccess/goaccess.conf` of
+[portal-compose](https://github.com/MaRDI4NFDI/portal-compose) is complete with exception of the following requirements:
 
-The setup contained in `docker-compose.yml` and `goaccess/goaccess.conf` of
-[portal-compose](github.com/MaRDI4NFDI/portal-compose) is complete with exception of the following requirements:
+## Logrotation
 
-### Mediawiki docker image modifications
+The size of traefik logs can easily take gigabytes and should be rotated with the unix
+tool logrotate (already running on mardi01). A logrotate config for traefik is given by https://github.com/MaRDI4NFDI/portal-compose/tree/main/traefik/logrotate.conf (should be placed in `/etc/logrotate.d`).
+Our goaccess image expects the two log files `access.log` and `access.log.1`, but can
+handle the case where the rotated file does not exist.
 
-- apache2 logs: use commit [90fdd1](https://github.com/MaRDI4NFDI/docker-wikibase/commit/90fdd1562783531691e26f2e1874aa42ea23f311) or newer of our custom mediawiki image [docker-wikibase](https://github.com/MaRDI4NFDI/docker-wikibase).
 
-  
-  Reason: The official mediawiki docker image is based on
-  [php:7.4-apache](https://hub.docker.com/layers/php/library/php/7.4-apache/images/sha256-f2e8c86002a794426a68537dc772c680865065da4127d3824f738e11bd4663af?context=explore),
-  which symlinks the log file to `/dev/stdout`, such that the logs are accessible with
-  `docker logs`. [docker-wikibase](https://github.com/MaRDI4NFDI/docker-wikibase) as of commit [90fdd1](https://github.com/MaRDI4NFDI/docker-wikibase/commit/90fdd1562783531691e26f2e1874aa42ea23f311) replaces these symlinks by real files and
-  tails them in order to still achieve logging with docker.
+<!-- ### Mediawiki docker image modifications -->
 
-### GeoIP Database
+<!-- - apache2 logs: use commit [90fdd1](https://github.com/MaRDI4NFDI/docker-wikibase/commit/90fdd1562783531691e26f2e1874aa42ea23f311) or newer of our custom mediawiki image [docker-wikibase](https://github.com/MaRDI4NFDI/docker-wikibase). -->
+
+<!--   Reason: The official mediawiki docker image is based on -->
+<!--   [php:7.4-apache](https://hub.docker.com/layers/php/library/php/7.4-apache/images/sha256-f2e8c86002a794426a68537dc772c680865065da4127d3824f738e11bd4663af?context=explore), -->
+<!--   which symlinks the log file to `/dev/stdout`, such that the logs are accessible with -->
+<!--   `docker logs`. [docker-wikibase](https://github.com/MaRDI4NFDI/docker-wikibase) as of commit [90fdd1](https://github.com/MaRDI4NFDI/docker-wikibase/commit/90fdd1562783531691e26f2e1874aa42ea23f311) replaces these symlinks by real files and -->
+<!--   tails them in order to still achieve logging with docker. -->
+
+## GeoIP Database
 
 In order to resolve IP geo locations, download the free database `GeoLite2 City` from https://www.maxmind.com/en/accounts/758058/geoip/downloads.
 An account was already registered with our MaRDI4NFDI groupware email account.

--- a/goaccess/goaccess.conf
+++ b/goaccess/goaccess.conf
@@ -1,7 +1,7 @@
 # GoAccess settings that are independent of docker-compose config
 # cf. https://raw.githubusercontent.com/allinurl/goaccess/master/config/goaccess.conf
-log-format COMBINED
+# log-format COMBINED
 tz Europe/Berlin
-anonymize-ip true
+# anonymize-ip true
 restore true
 persist true

--- a/traefik/logrotate.conf
+++ b/traefik/logrotate.conf
@@ -1,0 +1,15 @@
+# needs to run on host system
+# rename & copy this file to /etc/logrotate.d/traefik
+# TODO change hourly to daily
+/home/mardi-test-user/portal-compose/traefik-log/*.log {
+    hourly
+    missingok
+    rotate 10
+    compress
+    delaycompress
+    maxsize 40M
+    create 0644 root root
+    postrotate
+        docker kill --signal=USR1 reverse-proxy
+    endscript
+}


### PR DESCRIPTION
# MaRDI Pull Request

- setup goaccess to parse traefik logs rather than apache -- this includes not only requests of the web portal, but of all traefik managed services and, importantly, real visitor IPs.
- add logrotation for traefik (today traefik log is 2.4GB) with new image https://github.com/mardi4nfdi/docker-logrotate
#301 

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
