### PR TITLE
improve verbosity of backup test

### DIFF
--- a/test/test_backup.sh
+++ b/test/test_backup.sh
@@ -58,9 +58,12 @@ test_1() {
         if [[ "${files_created[*]}" != *images_*.gz*  ]]; then
             echo "          Images backup"
         fi
-        ### DEBUGGIN
+        ### DEBUGGING
         echo " DEBUG:"
         ls -ltr /data/*.gz
+        echo "###"
+        cat /data/backup.log
+        cat /data/restore.log
         ###
 
         exit 1

--- a/test/test_backup.sh
+++ b/test/test_backup.sh
@@ -43,7 +43,22 @@ test_1() {
     if [[ $((file_count_before+3)) == "$file_count_after" ]]; then
         echo " - Test backup OK: $((file_count_after - file_count_before))/3 backup files were created."
     else
-        echo " - Test backup FAILED: $((file_count_after - file_count_before))/3 backup files were created."
+        echo " - Test backup FAILED: $((file_count_after - file_count_before))/3 backup files were created:"
+        files_created=($(ls -tr /data/*.gz | tail -n $((file_count_after - file_count_before))))
+        for backup_file in "${files_created[@]}"; do
+            echo "      $backup_file"
+        done
+        echo "      MISSING: "
+        if [[ "${files_created[*]}" != *portal_db_backup_*.gz*  ]]; then
+            echo "          SQL backup"
+        fi
+        if [[ "${files_created[*]}" != *portal_xml_backup*.gz*  ]]; then
+            echo "          XML backup"
+        fi
+        if [[ "${files_created[*]}" != *images_*.gz*  ]]; then
+            echo "          Images backup"
+        fi
+
         exit 1
     fi
 }

--- a/test/test_backup.sh
+++ b/test/test_backup.sh
@@ -33,10 +33,19 @@ _break_wiki() {
 
 test_1() {
     echo "Test that backups are stored in the backup dir"
+    # count length of /data/backup.log before backup (will be empty on CI or clean
+    # system, but not on a running system)
+    if [[ -f /data/backup.log ]]; then
+        log_length=$(wc -l </data/backup.log)
+    else
+        log_length=0
+    fi
+
     # Run backup script, count backup files before and after
     file_count_before=$(_count_backup_files)
     /app/backup.sh &>/dev/null
     file_count_after=$(_count_backup_files)
+
     
     # Check that 3 backup files have been created (SQL-, XML-, uploaded-files- backups)
     # Please keep the spacing after [[ and around ==
@@ -58,13 +67,10 @@ test_1() {
         if [[ "${files_created[*]}" != *images_*.gz*  ]]; then
             echo "          Images backup"
         fi
-        ### DEBUGGING
-        echo " DEBUG:"
-        ls -ltr /data/*.gz
-        echo "###"
-        cat /data/backup.log
-        cat /data/restore.log
-        ###
+        # dump last record of backup.log
+        echo ""
+        echo "/data/backup.log (last record):"
+        tail -n +"$log_length" /data/backup.log
 
         exit 1
     fi

--- a/test/test_backup.sh
+++ b/test/test_backup.sh
@@ -58,6 +58,10 @@ test_1() {
         if [[ "${files_created[*]}" != *images_*.gz*  ]]; then
             echo "          Images backup"
         fi
+        ### DEBUGGIN
+        echo " DEBUG:"
+        ls -ltr /data/*.gz
+        ###
 
         exit 1
     fi


### PR DESCRIPTION
# MaRDI Pull Request

Previously, only the number of created backup files was reported (x/3), with a test failure if x<3.
Now the test reports in the case x<3, which files were found and which backup type failed (sql, xml or images)

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
