### PR TITLE
Pass env variables to backup grafana dashboards

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,8 @@ services:
       BACKUP_SCHEDULE: ${BACKUP_SCHEDULE}
       KEEP_DAYS: ${KEEP_DAYS:-30}
       BACKUP_CRON_ENABLE: ${BACKUP_CRON_ENABLE:-true}
+      GF_API_KEY: ${GF_API_KEY}
+      WB_PUBLIC_HOST_AND_PORT: ${WB_PUBLIC_HOST_AND_PORT}
     entrypoint: "/app/start.sh"
 
   reverse-proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,8 @@ services:
       KEEP_DAYS: ${KEEP_DAYS:-30}
       BACKUP_CRON_ENABLE: ${BACKUP_CRON_ENABLE:-true}
       GF_API_KEY: ${GF_API_KEY}
-      WB_PUBLIC_HOST_AND_PORT: ${WB_PUBLIC_HOST_AND_PORT}
+      GF_PUBLIC_HOST_AND_PORT: ${GF_PUBLIC_HOST_AND_PORT}
+      WIKIBASE_SCHEME: ${WIKIBASE_SCHEME:-https}
     entrypoint: "/app/start.sh"
 
   reverse-proxy:

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -88,6 +88,7 @@ GF_MAIL_USER=set-login@example.com
 GF_MAIL_PW=set-email-password
 GF_MAIL_FROMADDRESS=set-login@example.com
 GF_MAIL_FROMNAME=set-sender-name
+GF_API_KEY=grafana-api-key
 
 ## Watchtower settings
 WATCHTOWER_API_TOKEN=set-token

--- a/mediawiki/template.env
+++ b/mediawiki/template.env
@@ -88,6 +88,7 @@ GF_MAIL_USER=set-login@example.com
 GF_MAIL_PW=set-email-password
 GF_MAIL_FROMADDRESS=set-login@example.com
 GF_MAIL_FROMNAME=set-sender-name
+GF_PUBLIC_HOST_AND_PORT=grafana.portal.mardi4nfdi.de
 GF_API_KEY=grafana-api-key
 
 ## Watchtower settings


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Pass grafana information (key & host) to backup container, to enable API queries to grafana.
- Add variables also to template.env.
- API queries are then used in docker-backup to backup grafana dashboards (see https://github.com/MaRDI4NFDI/docker-backup/pull/37)
- Related to issue https://github.com/MaRDI4NFDI/portal-compose/issues/313

**Instructions for PR review**:
- [X] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [X] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [X] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
