### PR TITLE
Deactivate warnings

### DIFF
--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -23,7 +23,7 @@
 /*******************************/
 /* Disable UI error-reporting  */
 /*******************************/
-#ini_set( 'display_errors', 1 );
+#ini_set( 'display_errors', 0 );
 
 # Prevent new user registrations except by sysops
 $wgGroupPermissions['*']['createaccount'] = false;


### PR DESCRIPTION
Temporary fix to deactivate deprecation warnings, before I can find a more permanent solution through $wgDeprecationReleaseLimit

# MaRDI Pull Request

**Changes**:
- Display errors = 0

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
