### PR TITLE
Add wikibase.svc host for dev

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -29,7 +29,7 @@ services:
      - "${WDQS_FRONTEND_PORT}:80"
     restart: ${RESTART}
     environment:
-      - WIKIBASE_HOST=portal.mardi4nfdi.de
+      - WIKIBASE_HOST=wikibase.svc
 
   quickstatements:
     ports:
@@ -55,12 +55,16 @@ services:
 
   wdqs:
     restart: ${RESTART}
+    environment:
+     - WIKIBASE_HOST=wikibase.svc
 
   wdqs-proxy:
     restart: ${RESTART}
 
   wdqs-updater:
     restart: ${RESTART}
+    environment:
+     - WIKIBASE_HOST=wikibase.svc
 
   portainer:
     restart: ${RESTART}


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Overwrites WIKIBASE_HOST as wikibase.svc for using the Wikibase Query Service (i.e. SPARQL) in development. Otherwise, the production endpoint (portal.mardi4nfdi.de) is used, as defined in portal-compose.yml.

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
