### PR TITLE
Add mtu value for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -532,3 +532,9 @@ volumes:
   goaccess_db:
   matomo:
   shibboleth:
+
+networks:                                
+  default:                               
+    driver: bridge                       
+    driver_opts:                         
+      com.docker.network.driver.mtu: 1450


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- I am experiencing problems when accessing external API endpoints from within docker containers in production. I think this is due to our transfer to OpenStack, since we were already having the same problem in our other VMs.
- This is the solution we used for development (see https://mlohr.com/docker-mtu/ and https://portal.mardi4nfdi.de/wiki/Project:Docker_OpenStackVM)

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
