### PR TITLE
Increase blazegraph timeout to 1h

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -411,6 +411,7 @@ services:
       - WIKIBASE_SCHEME=${WIKIBASE_SCHEME:-https}
       - WDQS_HOST=wdqs.svc
       - WDQS_PORT=9999
+      - BLAZEGRAPH_OPTS='-Dorg.wikidata.query.rdf.tool.rdf.RdfRepository.timeout=3600'
     expose:
       - 9999
 


### PR DESCRIPTION
inspired by https://stackoverflow.com/a/52434226 which passes the blazegraph options directly according to

https://github.com/wikimedia/wikidata-query-rdf/blob/0922c4c4dead1e4937f3c3b4afeb89eb79bd808d/dist/src/script/runBlazegraph.sh#L144