### PR TITLE
Revert "Do not search mardi-items by default"

### DIFF
--- a/mediawiki/LocalSettings.d/Wikibase.php
+++ b/mediawiki/LocalSettings.d/Wikibase.php
@@ -35,7 +35,10 @@ $wgWBClientSettings['entitySources'] = [
 $wgWBClientSettings['itemAndPropertySourceName'] = 'mardi_source';
 // my_wiki is the MaRDI database
 $wgLocalDatabases = [ 'wiki_swmath', 'my_wiki' ];
-$wgNamespacesToBeSearchedDefault[120] = false; // wikibase-item
+
+// https://github.com/MaRDI4NFDI/portal-compose/issues/224
+$wgNamespacesToBeSearchedDefault[122] = true; // WB_PROPERTY_NAMESPACE===122
+
 if ( $wgDBname !== 'wiki_swmath' ){
 
 	wfLoadExtension( 'WikibaseRepository', "$IP/extensions/Wikibase/extension-repo.json" );


### PR DESCRIPTION
Reverts MaRDI4NFDI/portal-compose#442

The items were still included in the default search. Most likely the problem is that we include the so called "example settings" from Wikibase, here

https://github.com/MaRDI4NFDI/portal-compose/blob/17d65dfc1479695d728f65156da1274ab149b8f0/mediawiki/LocalSettings.d/Wikibase.php#L5C1-L5C67