### PR TITLE
Increase max db connections

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -9,4 +9,5 @@ innodb_log_file_size=32M
 log-bin
 sync_binlog=1
 server_id=1001
-log-basename=mardb 
+log-basename=mardb
+max_connections=1000


### PR DESCRIPTION
It avoids portal 500 problems like

MediaWiki internal error.

Original exception: [80160ebca09a7da5d38eebd3] / Wikimedia\Rdbms\DBConnectionError: Cannot access the database: Too many connections (mysql.svc:3306) Backtrace:

# MaRDI Pull Request

**Changes**:
- Increase max db connections to 1000

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
