### PR TITLE
Substitute TLD for MARDI_HOST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ data
 extensions-dev 
 docker-compose.override.yml
 grafana/grafana.ini
+oaipmh/cassandra.yaml
 prometheus/prometheus.yml
 images
 !images/favicon.png

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ x-common-variables: &wikibase_variables
   DB_USER: ${DB_USER:-sqluser}
   DB_PASS: ${DB_PASS}
   DB_NAME: ${DB_NAME:-my_wiki}
-  TLD: ${TLD:-de}
+  MARDI_HOST: ${MARDI_HOST:-portal.mardi4nfdi.de}
   DEPLOYMENT_ENV: ${DEPLOYMENT_ENV:-local}
   WIKIBASE_SCHEME: ${WIKIBASE_SCHEME:-https}
-  WIKIBASE_HOST: ${WIKIBASE_HOST:-portal.mardi4nfdi.${TLD}}
+  WIKIBASE_HOST: ${WIKIBASE_HOST:-portal.mardi4nfdi.de}
   WIKIBASE_PORT: ${WIKIBASE_PORT:-80}
-  QS_PUBLIC_SCHEME_HOST_AND_PORT: https://quickstatements.portal.mardi4nfdi.${TLD}
+  QS_PUBLIC_SCHEME_HOST_AND_PORT: https://quickstatements.${MARDI_HOST}
   TRAEFIK_PW: ${TRAEFIK_PW}
 x-extra-variables: &wikibase_extra_variables
   MW_ELASTIC_HOST: ${MW_ELASTIC_HOST:-elasticsearch.svc}
@@ -26,6 +26,7 @@ x-extra-variables: &wikibase_extra_variables
 services:
   statsd:
     image: ghcr.io/statsd/statsd
+
   redis-jobrunner:
     image: ghcr.io/mardi4nfdi/docker-redis-jobrunner
     depends_on:
@@ -44,6 +45,7 @@ services:
       MW_WG_ENABLE_UPLOADS:
       MATOMO_TOKEN: ${MATOMO_TOKEN}
       GOOGLE_OPENID_SECRET: ${GOOGLE_OPENID_SECRET}
+
   redis-rescheduler:
     image: ghcr.io/mardi4nfdi/docker-redis-jobrunner
     depends_on:
@@ -52,9 +54,11 @@ services:
     - ./redis-jobrunner-conf.json:/jobrunner/config.json:ro
     - shared_mardi_wikibase:/shared/
     - ./mediawiki/LocalSettings.d:/shared/LocalSettings.d:ro
+
   redis:
     container_name: redis
     image: redis:7
+
   cassandra-oai:
     hostname: cassandra-oai
     image: cassandra:4.1
@@ -66,6 +70,7 @@ services:
     - ./oaipmh/cassandra-env.sh:/etc/cassandra/cassandra-env.sh
     - ./oaipmh/jmxremote.access:/opt/java/openjdk/lib/management/jmxremote.access
     - ./oaipmh/jmxremote.password:/etc/cassandra/jmxremote.password
+
   cassandra-oai-setup:
     hostname: cassandra-oai-setup
     image: cassandra:4.1
@@ -75,6 +80,7 @@ services:
     volumes:
     - ./oaipmh/init-fizoai-database.sh:/init-fizoai-database.sh:ro
     - ./oaipmh/wait-for-it.sh:/wait-for-it.sh:ro
+
   cassandra-backup:
     hostname: cassandra-backup
     image: docker.dev.fiz-karlsruhe.de/cassandra-backup:5.2
@@ -89,6 +95,7 @@ services:
     - ./cassandra-backup:/backup
     depends_on:
     - cassandra-oai
+
   elasticsearch-oai:
     hostname: elasticsearch-oai
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.13
@@ -105,7 +112,6 @@ services:
     - es-logs:/usr/share/elasticsearch/logs
     - es-data:/usr/share/elasticsearch/data
     # - ./oaipmh/oai-elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:ro
-
 
   elasticsearch-oai-setup:
     hostname: elasticsearch-oai-setup
@@ -133,6 +139,7 @@ services:
     volumes:
     - ./oaipmh/fiz-oai-backend.properties:/usr/local/tomcat/conf/fiz-oai-backend.properties:ro
     - backend-logs:/usr/local/tomcat/logs
+
   oai-provider:
     hostname: oai-provider
     image: docker.dev.fiz-karlsruhe.de/oai-provider:1.2.7
@@ -147,7 +154,7 @@ services:
     - ./oaipmh/oaicat.properties:/usr/local/tomcat/conf/oaicat.properties:ro
     - provider-logs:/usr/local/tomcat/logs
     labels:
-    - traefik.http.routers.oai-provider.rule=Host(`oai.portal.mardi4nfdi.${TLD}`)
+    - traefik.http.routers.oai-provider.rule=Host(`oai.${MARDI_HOST}`)
     - traefik.http.routers.oai-provider.entrypoints=websecure
     - traefik.http.routers.oai-provider.tls.certResolver=le
     
@@ -187,12 +194,12 @@ services:
       MATOMO_TOKEN: ${MATOMO_TOKEN}
       GOOGLE_OPENID_SECRET: ${GOOGLE_OPENID_SECRET}
     labels:
-      - traefik.http.routers.service-wikibase.rule=Host(`portal.mardi4nfdi.${TLD}`,`swmath.portal.mardi4nfdi.${TLD}`,`staging.swmath.org`)
+      - traefik.http.routers.service-wikibase.rule=Host(`${MARDI_HOST}`,`swmath.${MARDI_HOST}`,`staging.swmath.org`)
       - traefik.http.routers.service-wikibase.entrypoints=websecure
       - traefik.http.routers.service-wikibase.tls.certResolver=le
       - traefik.http.routers.service-wikibase.service=wikibase-service
       - traefik.http.services.wikibase-service.loadbalancer.server.port=80
-      - traefik.http.routers.service-wikimongo.rule=Host(`wikimongo.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.service-wikimongo.rule=Host(`wikimongo.${MARDI_HOST}`)
       - traefik.http.routers.service-wikimongo.entrypoints=websecure
       - traefik.http.routers.service-wikimongo.tls.certResolver=le
       - traefik.http.routers.service-wikimongo.service=wikimongo-service
@@ -298,7 +305,7 @@ services:
       MYSQL_PASSWORD: ${DB_API_PASS}
       MYSQL_DATABASE: ${DB_NAME}
     labels:
-      - traefik.http.routers.importer-api.rule=Host(`importer.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.importer-api.rule=Host(`importer.${MARDI_HOST}`)
       - traefik.http.routers.importer-api.entrypoints=websecure
       - traefik.http.routers.importer-api.tls.certResolver=le
 
@@ -349,7 +356,7 @@ services:
     networks:
       - default
     labels:
-      - traefik.http.routers.dashboard.rule=Host(`traefik.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.dashboard.rule=Host(`traefik.${MARDI_HOST}`)
       - traefik.http.routers.dashboard.entrypoints=websecure
       - traefik.http.routers.dashboard.tls.certResolver=le
       - traefik.http.routers.dashboard.service=api@internal
@@ -398,14 +405,14 @@ services:
     networks:
       default:
         aliases:
-         - query.portal.mardi4nfdi.${TLD}
+         - query.${MARDI_HOST}
          - wdqs-frontend.svc
     environment:
-      - WIKIBASE_HOST=portal.mardi4nfdi.${TLD}
+      - WIKIBASE_HOST=${MARDI_HOST}
       - WDQS_HOST=wdqs-proxy.svc
       - BRAND_TITLE=MaRDIQueryService
     labels:
-      - traefik.http.routers.service-wdqs-frontend.rule=Host(`query.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.service-wdqs-frontend.rule=Host(`query.${MARDI_HOST}`)
       - traefik.http.routers.service-wdqs-frontend.entrypoints=websecure
       - traefik.http.routers.service-wdqs-frontend.tls.certResolver=le
 
@@ -420,7 +427,7 @@ services:
         aliases:
          - wdqs.svc
     environment:
-      - WIKIBASE_HOST=portal.mardi4nfdi.${TLD}
+      - WIKIBASE_HOST=${MARDI_HOST}
       - WIKIBASE_SCHEME=${WIKIBASE_SCHEME:-https}
       - WDQS_HOST=wdqs.svc
       - WDQS_PORT=9999
@@ -428,6 +435,7 @@ services:
     expose:
       - 9999
   # cf https://github.com/MaRDI4NFDI/wikibase-release-pipeline/blob/main/build/WDQS-proxy/README.md
+
   wdqs-proxy:
     image: "${WDQS_PROXY_IMAGE_NAME:-wikibase/wdqs-proxy:wmde.6}"
     restart: unless-stopped
@@ -441,7 +449,7 @@ services:
         aliases:
          - wdqs-proxy.svc
     labels:
-      - traefik.http.routers.wdqs-proxy.rule=Host(`sparql.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.wdqs-proxy.rule=Host(`sparql.${MARDI_HOST}`)
       - traefik.http.routers.wdqs-proxy.entrypoints=websecure
       - traefik.http.routers.wdqs-proxy.tls.certResolver=le
 
@@ -457,7 +465,7 @@ services:
         aliases:
          - wdqs-updater.svc
     environment:
-     - WIKIBASE_HOST=portal.mardi4nfdi.${TLD}
+     - WIKIBASE_HOST=${MARDI_HOST}
      - WIKIBASE_SCHEME=${WIKIBASE_SCHEME:-https}
      - WDQS_HOST=wdqs.svc
      - WDQS_PORT=9999
@@ -475,16 +483,16 @@ services:
     networks:
       default:
         aliases:
-         - quickstatements.portal.mardi4nfdi.${TLD}
+         - quickstatements.${MARDI_HOST}
     labels:
-      - traefik.http.routers.service-quickstatements.rule=Host(`quickstatements.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.service-quickstatements.rule=Host(`quickstatements.${MARDI_HOST}`)
       - traefik.http.routers.service-quickstatements.entrypoints=websecure
       - traefik.http.routers.service-quickstatements.tls.certResolver=le
     environment:
-      - QUICKSTATEMENTS_HOST=https://quickstatements.portal.mardi4nfdi.${TLD}
+      - QUICKSTATEMENTS_HOST=https://quickstatements.${MARDI_HOST}
       - WIKIBASE_SCHEME_AND_HOST=http://wikibase-docker.svc
-      - QS_PUBLIC_SCHEME_HOST_AND_PORT=https://quickstatements.portal.mardi4nfdi.${TLD}
-      - WB_PUBLIC_SCHEME_HOST_AND_PORT=https://portal.mardi4nfdi.${TLD}
+      - QS_PUBLIC_SCHEME_HOST_AND_PORT=https://quickstatements.${MARDI_HOST}
+      - WB_PUBLIC_SCHEME_HOST_AND_PORT=https://${MARDI_HOST}
       - WB_PROPERTY_NAMESPACE=122
       - "WB_PROPERTY_PREFIX=Property:"
       - WB_ITEM_NAMESPACE=120
@@ -501,7 +509,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock # needs access to docker process
       - portainer-data:/data # volume to save settings of portainer
     labels:
-      - traefik.http.routers.service-portainer.rule=Host(`portainer.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.service-portainer.rule=Host(`portainer.${MARDI_HOST}`)
       - traefik.http.routers.service-portainer.entrypoints=websecure
       - traefik.http.routers.service-portainer.tls.certResolver=le
       - traefik.http.services.portainer-docker.loadbalancer.server.port=9000
@@ -537,7 +545,7 @@ services:
       - --web.console.libraries=/usr/share/prometheus/console_libraries
       - --web.console.templates=/usr/share/prometheus/consoles
     labels:
-      - traefik.http.routers.prometheus.rule=Host(`prometheus.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.prometheus.rule=Host(`prometheus.${MARDI_HOST}`)
       - traefik.http.routers.prometheus.entrypoints=websecure
       - traefik.http.routers.prometheus.tls.certResolver=le
       - traefik.http.routers.prometheus.middlewares=auth
@@ -563,7 +571,7 @@ services:
       - grafana_data:/var/lib/grafana
       - ./grafana/:/etc/grafana/
     labels:
-      - traefik.http.routers.grafana.rule=Host(`grafana.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.grafana.rule=Host(`grafana.${MARDI_HOST}`)
       - traefik.http.routers.grafana.entrypoints=websecure
       - traefik.http.routers.grafana.tls.certResolver=le
 
@@ -590,7 +598,7 @@ services:
     environment:
       COLLECTOR_ZIPKIN_HTTP_PORT: 9411
     labels:
-      - traefik.http.routers.jaeger.rule=Host(`jaeger.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.jaeger.rule=Host(`jaeger.${MARDI_HOST}`)
       - traefik.http.routers.jaeger.entrypoints=websecure
       - traefik.http.routers.jaeger.tls.certResolver=le
       - traefik.http.routers.jaeger.middlewares=auth
@@ -629,7 +637,7 @@ services:
     volumes:
       - goaccess_report:/usr/share/nginx/html
     labels:
-      - traefik.http.routers.nginx.rule=Host(`stats.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.nginx.rule=Host(`stats.${MARDI_HOST}`)
       - traefik.http.routers.nginx.entrypoints=websecure
       - traefik.http.routers.nginx.tls.certResolver=le
       - traefik.http.routers.nginx.middlewares=auth
@@ -637,7 +645,7 @@ services:
   scholia:
     image: ghcr.io/mardi4nfdi/scholia:nightly
     labels:
-      - traefik.http.routers.scholia.rule=Host(`scholia.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.scholia.rule=Host(`scholia.${MARDI_HOST}`)
       - traefik.http.routers.scholia.entrypoints=websecure
       - traefik.http.routers.scholia.tls.certResolver=le
   
@@ -654,7 +662,7 @@ services:
       - MATOMO_DATABASE_PASSWORD=${MATOMO_DATABASE_PASSWORD}
       - MATOMO_DATABASE_DBNAME=${MATOMO_DATABASE_DBNAME}
     labels:
-      - traefik.http.routers.matomo.rule=Host(`matomo.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.matomo.rule=Host(`matomo.${MARDI_HOST}`)
       - traefik.http.routers.matomo.entrypoints=websecure
       - traefik.http.routers.matomo.tls.certResolver=le
 
@@ -674,7 +682,7 @@ services:
       - uptime-kuma:/app/data
     restart: always
     labels:
-      - traefik.http.routers.uptime.rule=Host(`uptime.portal.mardi4nfdi.${TLD}`)
+      - traefik.http.routers.uptime.rule=Host(`uptime.${MARDI_HOST}`)
       - traefik.http.routers.uptime.entrypoints=websecure
       - traefik.http.routers.uptime.tls.certResolver=le
 

--- a/mediawiki/LocalSettings.d/DeleteBatch.php
+++ b/mediawiki/LocalSettings.d/DeleteBatch.php
@@ -1,2 +1,0 @@
-<?php
-wfLoadExtension( 'DeleteBatch' );


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- This deletes the TLD variable and uses MARDI_HOST instead in preparation for https://github.com/MaRDI4NFDI/portal-compose/issues/461
- MARDI_HOST will be equal to portal.mardi4nfdi.de in production and staging.mardi4nfdi.org for staging.
- delete DeleteBatch extension (unnecessary)

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
