### PR TITLE
Fix issue in WDQS container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,6 +237,7 @@ services:
       - WIKIBASE_SCHEME=${WIKIBASE_SCHEME:-https}
       - WDQS_HOST=wdqs.svc
       - WDQS_PORT=9999
+      - ALLOWLIST=whitelist.txt
       - BLAZEGRAPH_OPTS='-Dorg.wikidata.query.rdf.tool.rdf.RdfRepository.timeout=3600'
     expose:
       - 9999


### PR DESCRIPTION
# MaRDI Pull Request

For some reason the file in the WDQS container is
called whitelist.txt while the service defaults to a file named allowlist.txt

Closes #473




**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [x] Checkout (Test changes locally) Tested by setting the environment variable temporary on in production

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
