### PR TITLE
Increase mysql max_allowed_package

### DIFF
--- a/my.cnf
+++ b/my.cnf
@@ -11,3 +11,4 @@ sync_binlog=1
 server_id=1001
 log-basename=mardb
 max_connections=1000
+max_allowed_packet=100M


### PR DESCRIPTION
The maintenance script nukeNS gets rid of all unnecessary text blobs after deleting the pages. The implementation requires a larger package size as we currently run into https://www.mediawiki.org/wiki/Topic:Wtok4l6ov3jh0dc7

# MaRDI Pull Request

**Changes**:
- 
- 
-  

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
