### PR TITLE
Remove normal jobrunner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,29 +90,6 @@ services:
       - traefik.http.routers.service-wikimongo.tls.certResolver=le
       - traefik.http.routers.service-wikimongo.service=wikimongo-service
       - traefik.http.services.wikimongo-service.loadbalancer.server.port=8081
-  
-  wikibase_jobrunner:
-    image: *wikibase-image
-    entrypoint: /bin/bash
-    command:  /jobrunner-entrypoint.sh
-    links:
-      - mysql
-      - mongo
-    depends_on:
-      - mysql
-      - mongo
-    restart: always
-    volumes:
-      - shared_mardi_wikibase:/shared/
-      - ./mediawiki/LocalSettings.d:/shared/LocalSettings.d:ro
-      - ./mediawiki/jobrunner-entrypoint.sh:/jobrunner-entrypoint.sh
-    networks:
-      default:
-        aliases:
-          - wikibase-jobrunner.svc
-    environment:
-      <<: *wikibase_variables
-      MAX_JOBS: ${MAX_JOBS}
       
   mysql:
     image: *mysql-image


### PR DESCRIPTION
To avoid inference between redis-jobrunner and the legacy jobrunner we shut down the legacy jobrunner

# MaRDI Pull Request

**Changes**:
- 
- 
-  

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
