### PR TITLE
Update oai backend

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -29,7 +29,7 @@ x-nginx-image: &nginx-image
 x-node-exporter-image: &node-exporter-image
   prom/node-exporter:latest
 x-oai-backend-image: &oai-backend-image
-  docker.dev.fiz-karlsruhe.de/oai-backend:1.2.8
+  docker.dev.fiz-karlsruhe.de/oai-backend:1.2.11
 x-oai-provider-image: &oai-provider-image
   docker.dev.fiz-karlsruhe.de/oai-provider:1.2.7
 x-prometheus-image: &prometheus-image

--- a/oaipmh/fiz-oai-backend.properties
+++ b/oaipmh/fiz-oai-backend.properties
@@ -7,3 +7,4 @@ cassandra.datacenter=dc1
 elasticsearch.host=elasticsearch-oai
 elasticsearch.port=9200
 class.impl.search=de.fiz.oai.backend.service.impl.EsSearchServiceImpl
+checkItemIdentifierInContent=false


### PR DESCRIPTION
A fundamental problem with zbMATH and swMATH identifiers is that they don't have a prefix. Therefore the full identifier is not part of the plain rest API result. This caused that a check in the OAI-PMH API failed. To disable this check a new switch has been introduced in version 1.2.11.

See
https://github.com/ER-FIZKarlsruhe/fiz-oai-backend/issues/1
# MaRDI Pull Request

**Changes**:
- 
- 
-  

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
