### PR TITLE
Remove test network

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,6 @@ jobs:
         run: >
           MW_ADMIN_PASS=${{ secrets.MW_ADMIN_PASS }} 
           DB_PASS=${{ secrets.DB_PASS }}
-          docker network create test &&
           docker-compose -f docker-compose.yml -f docker-compose-extra.yml -f docker-compose-ci.yml up -d 
           
       # pauses CI execution and prints a temporary ssh url to the server for debugging


### PR DESCRIPTION
The test-network was used as a bridge between docker-compose and docker-compose stack. It was introduced in connection with #422

# MaRDI Pull Request

**Changes**:
- 
- 
-  

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
