### PR TITLE
Use ini file from wikibase to pass oauth param to qs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -269,7 +269,7 @@ services:
     container_name: mardi-quickstatements
     restart: unless-stopped
     volumes:
-      - quickstatements-data:/quickstatements/data
+      - quickstatements-data:/quickstatements/data:ro
     depends_on:
       - wikibase
     networks:
@@ -289,8 +289,6 @@ services:
       - "WB_PROPERTY_PREFIX=Property:"
       - WB_ITEM_NAMESPACE=120
       - "WB_ITEM_PREFIX=Item:"
-      - OAUTH_CONSUMER_KEY=${OAUTH_CONSUMER_KEY}
-      - OAUTH_CONSUMER_SECRET=${OAUTH_CONSUMER_SECRET}
 
   traefik:
     restart: always


### PR DESCRIPTION
There are now different conflicting mechanisms to pass oauth parameter to qs
* Set the ini file to read only for qs container
* Remove environment varables with oauth params for qs container

cf #502

# MaRDI Pull Request

**Changes**:
- 
- 
-  

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
