### PR TITLE
Add MSC classification

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ x-common-variables: &wikibase_variables
   DB_USER: ${DB_USER:-sqluser}
   DB_PASS: ${DB_PASS}
   DB_NAME: ${DB_NAME:-my_wiki}
+  MSC_USER: ${MSC_USER}
+  MSC_PASS: ${MSC_PASS}
   DEPLOYMENT_ENV: ${DEPLOYMENT_ENV:-local}
   WIKIBASE_SCHEME: ${WIKIBASE_SCHEME:-https}
   WIKIBASE_HOST: ${WIKIBASE_HOST:-portal.mardi4nfdi.de}

--- a/mediawiki/LocalSettings.d/ExternalData.php
+++ b/mediawiki/LocalSettings.d/ExternalData.php
@@ -1,0 +1,2 @@
+<?php
+wfLoadExtension( 'ExternalData' );

--- a/mediawiki/LocalSettings.d/MSC_classification.php
+++ b/mediawiki/LocalSettings.d/MSC_classification.php
@@ -1,0 +1,14 @@
+<?php
+$wgExternalDataSources['MSC'] = [
+    'server' => getenv('DB_SERVER'),
+    'type' => 'mysql',
+    'name' => 'my_wiki',
+    'user' => getenv('DB_USER'),
+    'password' => getenv('DB_PASS'),
+    'prepared' => <<<'SQL'
+SELECT msc_string
+FROM msc_id_mapping
+WHERE msc_id = ?
+SQL,
+	  'types' => 's'
+];

--- a/mediawiki/LocalSettings.d/MSC_classification.php
+++ b/mediawiki/LocalSettings.d/MSC_classification.php
@@ -2,9 +2,9 @@
 $wgExternalDataSources['MSC'] = [
     'server' => getenv('DB_SERVER'),
     'type' => 'mysql',
-    'name' => 'my_wiki',
-    'user' => getenv('DB_USER'),
-    'password' => getenv('DB_PASS'),
+    'name' => 'msc_classification',
+    'user' => getenv('MSC_USER'),
+    'password' => getenv('MSC_PASS'),
     'prepared' => <<<'SQL'
 SELECT msc_string
 FROM msc_id_mapping

--- a/mediawiki/LocalSettings.d/MSC_classification.php
+++ b/mediawiki/LocalSettings.d/MSC_classification.php
@@ -10,5 +10,5 @@ SELECT msc_string
 FROM msc_id_mapping
 WHERE msc_id = ?
 SQL,
-	  'types' => 's'
+    'types' => 's'
 ];


### PR DESCRIPTION
# MaRDI Pull Request

In our last MaRDI meeting we discussed showing the MSC classification labels directly from information stored in the database. Thus avoiding having to insert the MSC label in the knowledge graph. This PR would be a first step towards that.

**Changes**:
- Activate the ExternalData extension and define a query to get the label, once the info is the db.

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
