### PR TITLE
Disable verbose warnings in oai backend

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -96,6 +96,7 @@ services:
       - "ES_JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true -Xms2g -Xmx2g"
       - "LOG4J_FORMAT_MSG_NO_LOOKUPS=true"
       - discovery.type=single-node
+      - xpack.security.enabled=false
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
The oai backend sends out very verbose warnings regarding the elasticsearch configuration. This change suppresses that warning.

sample
```
07:05  INFO: processCrosswalkForItem Zbl34614

2024-07-19 14:36:56.509 WARN  [RestClient] - request [GET http://elasticsearch-oai:9200/items/_doc/Zbl34614] returned 1 warnings: [299 Elasticsearch-7.17.13-2b211dbb8bfdecaf7f5b44d356bdfe54b1050c13 "Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html to enable security."]

07:05  INFO: Updateing item datestamp 2024-07-19T14:36:56Z

07:05  INFO: processCrosswalkForItem Zbl34615

2024-07-19 14:36:56.518 WARN  [RestClient] - request [GET http://elasticsearch-oai:9200/items/_doc/Zbl34615] returned 1 warnings: [299 Elasticsearch-7.17.13-2b211dbb8bfdecaf7f5b44d356bdfe54b1050c13 "Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html to enable security."]

