### PR TITLE
updating the version of the OAI-PMH service from 1.3.0 to 1.3.1

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -31,7 +31,7 @@ x-node-exporter-image: &node-exporter-image
 x-oai-backend-image: &oai-backend-image
   docker.dev.fiz-karlsruhe.de/oai-backend:1.3.1
 x-oai-provider-image: &oai-provider-image
-  docker.dev.fiz-karlsruhe.de/oai-provider:1.3.1
+  docker.dev.fiz-karlsruhe.de/oai-provider:1.3.0
 x-prometheus-image: &prometheus-image
   prom/prometheus
 x-statsd: &statsd-image

--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -29,9 +29,9 @@ x-nginx-image: &nginx-image
 x-node-exporter-image: &node-exporter-image
   prom/node-exporter:latest
 x-oai-backend-image: &oai-backend-image
-  docker.dev.fiz-karlsruhe.de/oai-backend:1.3.0
+  docker.dev.fiz-karlsruhe.de/oai-backend:1.3.1
 x-oai-provider-image: &oai-provider-image
-  docker.dev.fiz-karlsruhe.de/oai-provider:1.3.0
+  docker.dev.fiz-karlsruhe.de/oai-provider:1.3.1
 x-prometheus-image: &prometheus-image
   prom/prometheus
 x-statsd: &statsd-image


### PR DESCRIPTION
This PR updates the docker-compose-extra.yml file by stating the fiz-oai-backend is version 1.3.1.