### PR TITLE
bump fiz-oai-backend to 1.3.1

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -29,7 +29,7 @@ x-nginx-image: &nginx-image
 x-node-exporter-image: &node-exporter-image
   prom/node-exporter:latest
 x-oai-backend-image: &oai-backend-image
-  docker.dev.fiz-karlsruhe.de/oai-backend:1.3.0
+  docker.dev.fiz-karlsruhe.de/oai-backend:1.3.1
 x-oai-provider-image: &oai-provider-image
   docker.dev.fiz-karlsruhe.de/oai-provider:1.3.0
 x-prometheus-image: &prometheus-image


### PR DESCRIPTION
This PR updates the docker-compose-extra.yml file by stating the fiz-oai-backend is version 1.3.1.