### PR TITLE
Speed up high-traffic wiki

### DIFF
--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -169,6 +169,8 @@ $wgMultiShardSiteStats = true;
 # https://www.mediawiki.org/wiki/Manual:$wgMainCacheType maybe we need to increase the size of the APC cache at some point in time
 $wgMainCacheType = CACHE_ACCEL;
 $wgSessionCacheType = CACHE_DB;
+// Speed up "On high-traffic wikis, this should be set to false, to avoid the need to check the file modification time, and to avoid the performance impact of unnecessary cache invalidations. " see https://www.mediawiki.org/wiki/Manual:$wgInvalidateCacheOnLocalSettingsChange
+$wgInvalidateCacheOnLocalSettingsChange=false;
 
 # MaRDI profile types items
 $wgMathProfileQueries['dataset']='?item wdt:P1460 wd:Q5984635';


### PR DESCRIPTION
# MaRDI Pull Request

 Speed up "On high-traffic wikis, this should be set to false, to avoid the need to check the file modification time, and to avoid the performance impact of unnecessary cache invalidations. " see https://www.mediawiki.org/wiki/Manual:$wgInvalidateCacheOnLocalSettingsChange

