### PR TITLE
pull latest wikibase backup image

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -17,7 +17,7 @@ x-jaegertracing-image: &jaegertracing-image
 x-latexml-image: &latexml-image
   physikerwelt/latexml
 x-mardi-backup-image: &mardi-backup-image
-  ghcr.io/mardi4nfdi/docker-backup:main
+  ghcr.io/mardi4nfdi/docker-backup
 x-mardi-importer-image: &mardi-importer-image
   ghcr.io/mardi4nfdi/docker-importer:main
 x-mardi-importer-api-image: &mardi-importer-api-image


### PR DESCRIPTION
# MaRDI Pull Request
I've realized we were pulling a backup image that had not been updated in the last 9 months.

**Changes**:
- Pull the latest backup image, which is pushed in the docker-wikibase CI.
- This will fix this: https://github.com/MaRDI4NFDI/portal-compose/issues/567

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
