### PR TITLE
Define memory limit for lua

### DIFF
--- a/mediawiki/LocalSettings.d/Scribunto.php
+++ b/mediawiki/LocalSettings.d/Scribunto.php
@@ -2,3 +2,4 @@
 ## Scribunto 
 wfLoadExtension( 'Scribunto' );
 $wgScribuntoDefaultEngine = 'luastandalone';
+$wgScribuntoEngineConf['luastandalone']['memoryLimit'] = 209715200; # bytes


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Explicitly define a memory limit for Lua of 200MB (currently deployed for testing)