### PR TITLE
Fix dns resolution for query.portal.mardi4nfdi.de

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,6 @@ services:
     networks:
       default:
         aliases:
-         - query.${WIKIBASE_HOST}
          - wdqs-frontend.svc
     environment:
       - WIKIBASE_HOST=wikibase.svc


### PR DESCRIPTION
Setting query... as an explicit alias creates a DNS entry within dockers internal DNS resolution mechanism.
This leads to the fact that queries won't reach the proxy, but go to the machine directly, which neither listens to HTTPS, nor does it know about their certificate.