### PR TITLE
Add namespace selector to Special:Export

### DIFF
--- a/mediawiki/LocalSettings.d/LocalSettings.override.php
+++ b/mediawiki/LocalSettings.d/LocalSettings.override.php
@@ -206,3 +206,5 @@ $wgWBRepoSettings['statementSections'] = [
         ],
     ],
 ];
+
+$wgExportFromNamespaces = true;


### PR DESCRIPTION
https://www.mediawiki.org/wiki/Manual:$wgExportFromNamespaces

By default there only is a category selector on Special:Export. This setting also add a namespace selector.

This allows for easy export of all Wikibase properties, or exporting a sample of pages in the Person namespace
