### PR TITLE
Update org-redirect to new format

### DIFF
--- a/traefik/conf/org-redirect.yml
+++ b/traefik/conf/org-redirect.yml
@@ -1,7 +1,8 @@
 http:
   routers:
     home:
-      rule: Host(`mardi4nfdi.org`,`www.mardi4nfdi.org`)
+      rule:  Host(`mardi4nfdi.org`) ||
+        Host(`www.mardi4nfdi.org`)
       service: whoami-docker@docker
       entryPoints: [websecure]
       tls:


### PR DESCRIPTION
As discussed in the MaRDI chat
```
Tim Conrad (MaRDI) @tconrad
Moderator
Owner
1:14 PM
Other topic: at the moment this is pointing to our open-stack project: (www.)[mardi4nfdi.org|https://www.mardi4nfdi.org/]
Apparently we are not handling it correctly.


tconrad
It shows "404 page not found"
mschubotz
Moritz Schubotz (MaRDI) @mschubotz
Moderator
Owner
1:18 PM
Das ist de
Nicht org
tconrad
Tim Conrad (MaRDI) @tconrad
Moderator
Owner
1:19 PM
nee - auch die org
mschubotz
Moritz Schubotz (MaRDI) @mschubotz
Moderator
Owner
1:19 PM
Was meinst du mit openstack Projekt
tconrad
Tim Conrad (MaRDI) @tconrad
Moderator
Owner
1:19 PM
Zeigt auf unsere VMs
mschubotz
Moritz Schubotz (MaRDI) @mschubotz
Moderator
Owner
1:20 PM
Wo soll die hinzeigen
Bisher ist .org meiner Meinung nach absichtlich nicht konfiguriert
Ich kann es aber weiterleiten wenn ich weiß wohin
tconrad
Tim Conrad (MaRDI) @tconrad
Moderator
Owner
1:24 PM
Thomas Bender sagt: "https://www.mardi4nfdi.org" soll nach "https://www.mardi4nfdi.de" umgeleitet werden
mschubotz
Moritz Schubotz (MaRDI) @mschubotz
Moderator
Owner
1:25 PM
na gut, dann machen wir das doch
https://github.com/MaRDI4NFDI/portal-compose/blob/main/traefik/conf/org-redirect.yml
mh... tatsächlich sollte das so sein
```
This PR updates that to the new format.