### PR TITLE
Reduce log size

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 x-cassandra-oai: &cassandra-oai-image
   cassandra:4.1
 x-cassandra-backup-image: &cassandra-backup-image
@@ -51,6 +49,11 @@ x-whoami: &whoami-image
 x-flask: &flask-image
   tiangolo/uwsgi-nginx-flask:latest-2024-12-02
 
+logging:
+  driver: "json-file"
+  options:
+    max-size: "100m"
+    max-file: "5"
 services:
   statsd:
     image: *statsd-image


### PR DESCRIPTION
As an intermediate step towards problems related
to logging we should reduce the overall size.
In general I would think we should transition to logstash.

* remove the version which is deprecated
