### PR TITLE
Increase timeout when retrieving wikibase data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,6 +263,7 @@ services:
       - WIKIBASE_SCHEME=${WIKIBASE_SCHEME:-https}
       - WDQS_HOST=wdqs.svc
       - WDQS_PORT=9999
+      - UPDATER_OPTS='-Dorg.wikidata.query.rdf.tool.wikibase.WikibaseRepository.timeout=15000'
     labels:
       - traefik.enable=false
 


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Increase the timeout to fix error in the wdqs updater when retrieving data from wikibase
- This should fix https://github.com/MaRDI4NFDI/portal-compose/issues/630

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
