### PR TITLE
Math tex max length

### DIFF
--- a/mediawiki/LocalSettings.d/MathSearch.php
+++ b/mediawiki/LocalSettings.d/MathSearch.php
@@ -1,3 +1,0 @@
-<?php
-
-$wgMathSearchContentTexMaxLength = 30000;

--- a/mediawiki/LocalSettings.d/Wikibase.php
+++ b/mediawiki/LocalSettings.d/Wikibase.php
@@ -86,4 +86,7 @@ if ( $wgDBname !== 'wiki_swmath' ){
 			'length' => 1000,
 		],
 	];
+	# Math-specific string limits
+	$wgMathSearchContentTexMaxLength = 30000;
+	$wgMathTexMaxLength = 30000;
 }

--- a/mediawiki/LocalSettings.d/Wikibase.php
+++ b/mediawiki/LocalSettings.d/Wikibase.php
@@ -79,9 +79,6 @@ if ( $wgDBname !== 'wiki_swmath' ){
 		'VT:string' => [
 			'length' => 200000,
 		],
-		'PT:math' => [
-			'length' => 200000,
-		],
 		'multilang' => [
 			'length' => 2000,
 		],


### PR DESCRIPTION
Configures max input size of Tex input using new Math extension setting introduced in 

https://github.com/wikimedia/mediawiki-extensions-Math/commit/78b9659e4f7865d580218ece63fcd3f940f7112f

See https://github.com/MaRDI4NFDI/portal-compose/issues/632


