### PR TITLE
Use display_title for search ranking

### DIFF
--- a/mediawiki/LocalSettings.d/DisplayTitle.php
+++ b/mediawiki/LocalSettings.d/DisplayTitle.php
@@ -5,3 +5,14 @@ $wgRestrictDisplayTitle=false;
 # The Display Title extension allows a page's display title to be used as the default link text in links to the page - both links from other pages as well as self-links on the page.
 # https://www.mediawiki.org/wiki/Extension:Display_Title
 wfLoadExtension( 'DisplayTitle' );
+// Replace display_title with title fields otherwise keep the defaults from https://gerrit.wikimedia.org/g/mediawiki/extensions/CirrusSearch/%2B/HEAD/docs/settings.txt
+$wgCirrusSearchWeights = [
+    'display_title' => 20,
+    'redirect' => 15,
+    'category' => 8,
+    'heading' => 5,
+    'opening_text' => 3,
+    'text' => 1,
+    'auxiliary_text' => 0.5,
+    'file_text' => 0.5,
+];


### PR DESCRIPTION
Instead of using the regular title, use the displaytitle for ranking.