### PR TITLE
Undo display title

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,7 @@ x-common-variables: &wikibase_variables
   NFDI_AAI_SECRET: ${NFDI_AAI_SECRET}
   MW_ELASTIC_HOST: ${MW_ELASTIC_HOST:-elasticsearch.svc}
   MW_ELASTIC_PORT: ${MW_ELASTIC_PORT:-9200}
-  TREFIK_PORT: ${TREFIK_PORT:-80}
-
+  TRAEFIK_PORT: ${TRAEFIK_PORT:-80}
 services:
   wikibase:
     image: *wikibase-image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ x-common-variables: &wikibase_variables
   NFDI_AAI_SECRET: ${NFDI_AAI_SECRET}
   MW_ELASTIC_HOST: ${MW_ELASTIC_HOST:-elasticsearch.svc}
   MW_ELASTIC_PORT: ${MW_ELASTIC_PORT:-9200}
+  TREFIK_PORT: ${TREFIK_PORT:-80}
 
 services:
   wikibase:
@@ -299,7 +300,7 @@ services:
     container_name: reverse-proxy
     ports:
       - 443:443 # HTTPS port
-      - 80:80 # HTTP port
+      - ${TREFIK_PORT}:80 # HTTP port
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ x-common-variables: &wikibase_variables
   NFDI_AAI_SECRET: ${NFDI_AAI_SECRET}
   MW_ELASTIC_HOST: ${MW_ELASTIC_HOST:-elasticsearch.svc}
   MW_ELASTIC_PORT: ${MW_ELASTIC_PORT:-9200}
-  TRAEFIK_PORT: ${TRAEFIK_PORT:-80}
+  TRAEFIK_HTTP_PORT: ${TRAEFIK_HTTP_PORT:-80}
 services:
   wikibase:
     image: *wikibase-image
@@ -299,7 +299,7 @@ services:
     container_name: reverse-proxy
     ports:
       - 443:443 # HTTPS port
-      - ${TREFIK_PORT}:80 # HTTP port
+      - ${TRAEFIK_HTTP_PORT}:80 # HTTP port
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock # So that Traefik can listen to the Docker events
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro

--- a/mediawiki/LocalSettings.d/DisplayTitle.php
+++ b/mediawiki/LocalSettings.d/DisplayTitle.php
@@ -7,7 +7,7 @@ $wgRestrictDisplayTitle=false;
 wfLoadExtension( 'DisplayTitle' );
 // Replace display_title with title fields otherwise keep the defaults from https://gerrit.wikimedia.org/g/mediawiki/extensions/CirrusSearch/%2B/HEAD/docs/settings.txt
 $wgCirrusSearchWeights = [
-    'display_title' => 20,
+    'title' => 20,
     'redirect' => 15,
     'category' => 8,
     'heading' => 5,


### PR DESCRIPTION
Undo display title overwrite

It fails with the following error

<img width="1002" alt="Screenshot 2025-03-27 at 16 33 22" src="https://github.com/user-attachments/assets/ef67973b-a843-4841-b9ae-8739424fb5c1" />
