### PR TITLE
Temporary disable linkedwiki

### DIFF
--- a/mediawiki/LocalSettings.d/LinkedWiki.php
+++ b/mediawiki/LocalSettings.d/LinkedWiki.php
@@ -1,5 +1,5 @@
 <?php
-wfLoadExtension( 'LinkedWiki' );
+# wfLoadExtension( 'LinkedWiki' );
 
 # Linked-Wiki Configuration
 $wgLinkedWikiConfigSPARQLServices["mardi"] = array(


### PR DESCRIPTION
This extension breaks with the latest master branch due to https://phabricator.wikimedia.org/T388624

Disable it for now, as it might not be used anyhow.
