### PR TITLE
Revert "Temporary disable linkedwiki"

### DIFF
--- a/mediawiki/LocalSettings.d/LinkedWiki.php
+++ b/mediawiki/LocalSettings.d/LinkedWiki.php
@@ -1,5 +1,5 @@
 <?php
-# wfLoadExtension( 'LinkedWiki' );
+wfLoadExtension( 'LinkedWiki' );
 
 # Linked-Wiki Configuration
 $wgLinkedWikiConfigSPARQLServices["mardi"] = array(


### PR DESCRIPTION
This reverts commit 72f4ea959be87decf24264571e33bb5ec10f095d.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled a core extension to activate enhanced linking functionality within the MediaWiki environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->