### PR TITLE
Enable ProofreadPage

### DIFF
--- a/mediawiki/LocalSettings.d/ProofreadPage.php
+++ b/mediawiki/LocalSettings.d/ProofreadPage.php
@@ -1,0 +1,4 @@
+<php
+if ( preg_match( '/wikisource$/', $wgDBname, $match ) === 1 ) {
+  wfLoadExtension( 'ProofreadPage' );
+}


### PR DESCRIPTION
Only for wikisource wikis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The proofreading tool now activates automatically on relevant platforms based on specific criteria, ensuring the feature appears only where it applies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->