### PR TITLE
Add configuration to access abstracts in db

### DIFF
--- a/mediawiki/LocalSettings.d/Abstract_db_access.php
+++ b/mediawiki/LocalSettings.d/Abstract_db_access.php
@@ -1,0 +1,14 @@
+<?php
+$wgExternalDataSources['AbstractDB'] = [
+    'server' => getenv('DB_SERVER'),
+    'type' => 'mysql',
+    'name' => 'paper_abstracts_db',
+    'user' => getenv('MSC_USER'),
+    'password' => getenv('MSC_PASS'),
+    'prepared' => <<<'SQL'
+SELECT abstract, abstract_source, summary, summary_source
+FROM paper_abstracts
+WHERE paper_id = ?
+SQL,
+    'types' => 's'
+];


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- As discussed in https://github.com/MaRDI4NFDI/MaRDIRoadmap/issues/97 we plan to have the abstracts for some papers saved in an external DB to avoid overwhelming the KG and SPARQL server with string data.
- This gives access to this table using the ExternalData extension.

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new external data source configuration that enables access to paper abstract and summary data stored in a MySQL database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->