### PR TITLE
changing back wikibase tag from main to 1.44, as the test was successfull

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,11 @@ x-quickstatements-image: &quickstatements-image
 x-redis: &redis-image
   redis:7
 x-redis-jobrunner: &redis-jobrunner-image
-  ghcr.io/mardi4nfdi/docker-redis-jobrunner:main
+  ghcr.io/mardi4nfdi/docker-redis-jobrunner:1.44
 x-traefik-image: &traefik-image
   traefik:v2.8
 x-wikibase: &wikibase-image
-  ghcr.io/mardi4nfdi/docker-wikibase:main
+  ghcr.io/mardi4nfdi/docker-wikibase:1.44
 x-wdqs-image: &wdqs-image
   ghcr.io/wmde/wikibase/wdqs:dev-9186217118
 x-wdqs-frontend-image: &wdqs-frontend-image


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- wikibase tag changed from main to 1.44

**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated service versions for redis-jobrunner and wikibase to use the 1.44 image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->