### PR TITLE
Create chat.portal.mardi4nfdi.de

### DIFF
--- a/traefik/conf/chat.yml
+++ b/traefik/conf/chat.yml
@@ -1,0 +1,14 @@
+http:
+  routers:
+    to-chat:
+      rule:  Host(`chat.portal.mardi4nfdi.de`)
+      service: chat
+      entryPoints: [websecure]
+      tls:
+        certResolver: le
+  services:
+    # Define how to reach an existing service on our infrastructure
+    chat:
+      loadBalancer:
+        servers:
+        - url: http://130.73.240.218


### PR DESCRIPTION
Following https://doc.traefik.io/traefik/master/routing/overview/#example-with-a-file-provider

Bug: https://github.com/MaRDI4NFDI/portal-compose/issues/680


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled secure HTTPS access to the chat application via a new routing configuration. Users can now access the chat service at chat.portal.mardi4nfdi.de.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->