### PR TITLE
chore: Update OAI backend image to v1.5.3 in docker-compose

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -25,7 +25,7 @@ x-nginx-image: &nginx-image
 x-node-exporter-image: &node-exporter-image
   prom/node-exporter:latest
 x-oai-backend-image: &oai-backend-image
-  docker.dev.fiz-karlsruhe.de/oai-backend:1.5.2
+  docker.dev.fiz-karlsruhe.de/oai-backend:1.5.3
 x-oai-provider-image: &oai-provider-image
   docker.dev.fiz-karlsruhe.de/oai-provider:1.5.1
 x-prometheus-image: &prometheus-image


### PR DESCRIPTION
This PR updates the OAI-Backend Docker image from 1.5.1 to 1.5.3 in docker-compose-extra.yml.