### PR TITLE
give namespace permissions to all

### DIFF
--- a/mediawiki/LocalSettings.d/mardi_namespaces.php
+++ b/mediawiki/LocalSettings.d/mardi_namespaces.php
@@ -82,7 +82,7 @@ $wgNamespaceProtection[NS_QUANTITY] = array( 'overwriteprofilepages' );
 $wgNamespaceProtection[NS_TASK] = array( 'overwriteprofilepages' );
 
 
-$wgGroupPermissions['sysop']['overwriteprofilepages'] = true;
+$wgGroupPermissions['*']['overwriteprofilepages'] = true;
 
 $wgContentNamespaces[] = NS_FORMULA;
 $wgContentNamespaces[] = NS_PERSON;


### PR DESCRIPTION
Give permissions to all users to be able to create and edit Namespace pages so that TA members can create them by hand.
@physikerwelt We should probably do this before running the large profile page script, in case something goes wrong

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- All users can now access actions that require the 'overwriteprofilepages' permission; this was previously limited to certain user groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->