### PR TITLE
Extend namespace permissions

### DIFF
--- a/mediawiki/LocalSettings.d/mardi_namespaces.php
+++ b/mediawiki/LocalSettings.d/mardi_namespaces.php
@@ -82,7 +82,7 @@ $wgNamespaceProtection[NS_QUANTITY] = array( 'overwriteprofilepages' );
 $wgNamespaceProtection[NS_TASK] = array( 'overwriteprofilepages' );
 
 
-$wgGroupPermissions['sysop']['overwriteprofilepages'] = true;
+$wgGroupPermissions['*']['overwriteprofilepages'] = true;
 
 $wgContentNamespaces[] = NS_FORMULA;
 $wgContentNamespaces[] = NS_PERSON;

--- a/mediawiki/LocalSettings.d/mardi_namespaces.php
+++ b/mediawiki/LocalSettings.d/mardi_namespaces.php
@@ -78,11 +78,10 @@ $wgNamespaceProtection[NS_THEOREM] = array( 'overwriteprofilepages' );
 $wgNamespaceProtection[NS_RESEARCH_FIELD] = array( 'overwriteprofilepages' );
 $wgNamespaceProtection[NS_RESEARCH_PROBLEM] = array( 'overwriteprofilepages' );
 $wgNamespaceProtection[NS_MODEL] = array( 'overwriteprofilepages' );
-$wgNamespaceProtection[NS_QUANTITY] = array( 'overwriteprofilepages' );
 $wgNamespaceProtection[NS_TASK] = array( 'overwriteprofilepages' );
 
 
-$wgGroupPermissions['user']['overwriteprofilepages'] = true;
+$wgGroupPermissions['sysop']['overwriteprofilepages'] = true;
 
 $wgContentNamespaces[] = NS_FORMULA;
 $wgContentNamespaces[] = NS_PERSON;

--- a/mediawiki/LocalSettings.d/mardi_namespaces.php
+++ b/mediawiki/LocalSettings.d/mardi_namespaces.php
@@ -82,7 +82,7 @@ $wgNamespaceProtection[NS_QUANTITY] = array( 'overwriteprofilepages' );
 $wgNamespaceProtection[NS_TASK] = array( 'overwriteprofilepages' );
 
 
-$wgGroupPermissions['*']['overwriteprofilepages'] = true;
+$wgGroupPermissions['user']['overwriteprofilepages'] = true;
 
 $wgContentNamespaces[] = NS_FORMULA;
 $wgContentNamespaces[] = NS_PERSON;


### PR DESCRIPTION
Extend namespace permissions to all logged-in users as mentioned in https://github.com/MaRDI4NFDI/MaRDIRoadmap/issues/99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted permissions to remove special protection from the quantity namespace, aligning access controls with other namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->