### PR TITLE
Add mathmoddb namespaces to default search

### DIFF
--- a/mediawiki/LocalSettings.d/mardi_namespaces.php
+++ b/mediawiki/LocalSettings.d/mardi_namespaces.php
@@ -106,5 +106,10 @@ $wgNamespacesToBeSearchedDefault[NS_PERSON] = true;
 $wgNamespacesToBeSearchedDefault[NS_PUBLICATION] = true;
 $wgNamespacesToBeSearchedDefault[NS_SOFTWARE] = true;
 $wgNamespacesToBeSearchedDefault[NS_DATASET] = true;
+$wgNamespacesToBeSearchedDefault[NS_RESEARCH_FIELD] = true;
+$wgNamespacesToBeSearchedDefault[NS_RESEARCH_PROBLEM] = true;
+$wgNamespacesToBeSearchedDefault[NS_MODEL] = true;
+$wgNamespacesToBeSearchedDefault[NS_QUANTITY] = true;
+$wgNamespacesToBeSearchedDefault[NS_TASK] = true;
 
 


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Profile pages related to MathModDB should also be showed in the result list by default.
- This improves the usability for TA4 and people contributing to MathModDB.


**Instructions for PR review**:
- [ ] Conceptual Review (Logic etc...) 
- [ ] Code Review (Review your implementation) 
- [ ] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [ ] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [ ] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
