### PR TITLE
Add restart policy to dlockss-node service

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -104,6 +104,7 @@ services:
   dlockss-node:
     hostname: dlockssnode
     image: *dlockss-node-image
+    restart: unless-stopped
     environment:
       DLOCKSS_IPFS_NODE: "/dns4/ipfs/tcp/5001"
       DLOCKSS_NODE_NAME: MaRDI4NFDI


### PR DESCRIPTION
restart dlockss (required if IPFS node is still starting as it does not have a proper health check yet)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service resilience by enabling automatic restart on failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->