### PR TITLE
Add DLOCKSS_IDENTITY_PATH to environment variables

### DIFF
--- a/docker-compose-extra.yml
+++ b/docker-compose-extra.yml
@@ -108,8 +108,10 @@ services:
     environment:
       DLOCKSS_IPFS_NODE: "/dns4/ipfs/tcp/5001"
       DLOCKSS_NODE_NAME: MaRDI4NFDI
+      DLOCKSS_IDENTITY_PATH: "/ipfs/keystore"
     volumes:
     - ./dlockss-files:/data:ro
+    - ipfs-data:/ipfs/:ro
     depends_on:
     - ipfs
     labels:


### PR DESCRIPTION
use the same peer_id for ipfs and dlockss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated distributed storage service configuration for improved data persistence and management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->